### PR TITLE
fix: long query parameter set and event model parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,5 +396,5 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
-
+.idea
 *.Net.xml

--- a/Polymarket.Net/Clients/GammaApi/PolymarketRestClientGammaApi.cs
+++ b/Polymarket.Net/Clients/GammaApi/PolymarketRestClientGammaApi.cs
@@ -251,9 +251,9 @@ namespace Polymarket.Net.Clients.GammaApi
 
         /// <inheritdoc />
         public async Task<WebCallResult<PolymarketEvent[]>> GetEventsAsync(
-            long[]? ids = null,
+            string[]? ids = null,
             long? tagId = null,
-            long[]? excludeTagIds = null,
+            string[]? excludeTagIds = null,
             string[]? slugs = null,
             string? tagSlug = null,
             bool? relatedTags = null,
@@ -280,9 +280,9 @@ namespace Polymarket.Net.Clients.GammaApi
             CancellationToken ct = default)
         {
             var parameters = new ParameterCollection();
-            parameters.AddOptional("id", ids?.Cast<object>().ToArray());
+            parameters.AddOptional("id", ids);
             parameters.AddOptional("tag_id", tagId);
-            parameters.AddOptional("exclude_tag_id", excludeTagIds?.Cast<object>().ToArray());
+            parameters.AddOptional("exclude_tag_id", excludeTagIds);
             parameters.AddOptional("slug", slugs);
             parameters.AddOptional("tag_slug", tagSlug);
             parameters.AddOptionalBoolString("related_tags", relatedTags);

--- a/Polymarket.Net/Clients/GammaApi/PolymarketRestClientGammaApi.cs
+++ b/Polymarket.Net/Clients/GammaApi/PolymarketRestClientGammaApi.cs
@@ -17,6 +17,7 @@ using Polymarket.Net.Clients.MessageHandlers;
 using Polymarket.Net.Objects;
 using Polymarket.Net.Objects.Models;
 using System.Collections.Generic;
+using System.Linq;
 using Polymarket.Net.Enums;
 using CryptoExchange.Net.RateLimiting.Guards;
 
@@ -279,9 +280,9 @@ namespace Polymarket.Net.Clients.GammaApi
             CancellationToken ct = default)
         {
             var parameters = new ParameterCollection();
-            parameters.AddOptional("id", ids);
+            parameters.AddOptional("id", ids?.Cast<object>().ToArray());
             parameters.AddOptional("tag_id", tagId);
-            parameters.AddOptional("exclude_tag_id", excludeTagIds);
+            parameters.AddOptional("exclude_tag_id", excludeTagIds?.Cast<object>().ToArray());
             parameters.AddOptional("slug", slugs);
             parameters.AddOptional("tag_slug", tagSlug);
             parameters.AddOptionalBoolString("related_tags", relatedTags);

--- a/Polymarket.Net/Interfaces/Clients/GammaApi/IPolymarketRestClientGammaApi.cs
+++ b/Polymarket.Net/Interfaces/Clients/GammaApi/IPolymarketRestClientGammaApi.cs
@@ -221,9 +221,9 @@ namespace Polymarket.Net.Interfaces.Clients.GammaApi
         /// <param name="ascending">["<c>ascending</c>"] Ascending order</param>
         /// <param name="ct">Cancellation token</param>
         Task<WebCallResult<PolymarketEvent[]>> GetEventsAsync(
-            long[]? ids = null,
+            string[]? ids = null,
             long? tagId = null,
-            long[]? excludeTagIds = null,
+            string[]? excludeTagIds = null,
             string[]? slugs = null,
             string? tagSlug = null,
             bool? relatedTags = null,

--- a/Polymarket.Net/Objects/Models/PolymarketEvent.cs
+++ b/Polymarket.Net/Objects/Models/PolymarketEvent.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
+using CryptoExchange.Net.Converters.SystemTextJson;
 
 namespace Polymarket.Net.Objects.Models
 {
@@ -205,7 +206,8 @@ namespace Polymarket.Net.Objects.Models
         /// <summary>
         /// ["<c>parentEvent</c>"] Parent event
         /// </summary>
-        [JsonPropertyName("parentEvent")]
+        [JsonPropertyName("parentEventId")]
+        [JsonConverter(typeof(NumberStringConverter))]
         public string ParentEvent { get; set; } = string.Empty;
         /// <summary>
         /// ["<c>enableOrderBook</c>"] Enabled order book


### PR DESCRIPTION
This is PR to fix logic of retriving list of events from Polymarket.
It contains fixes for two possible problems:
1. AddOptions for ids list and for exclude_tag_id list don't work for long arrays. I've added fix with cast to object array.
2. Event has `parentEventId` field instead of `parentEvent`. For example here is the link for event: [Polymarket Event](https://gamma-api.polymarket.com/events/235049)