### PR TITLE
Added Polymarket Data API support to the client

### DIFF
--- a/Polymarket.Net.UnitTests/PolymarketRestIntegrationTests.cs
+++ b/Polymarket.Net.UnitTests/PolymarketRestIntegrationTests.cs
@@ -1,15 +1,17 @@
+using CryptoExchange.Net.Objects.Errors;
 using CryptoExchange.Net.Testing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NUnit.Framework;
-using System;
-using System.Threading.Tasks;
 using Polymarket.Net.Clients;
-using Polymarket.Net.Objects.Options;
+using Polymarket.Net.Clients.DataApi;
+using Polymarket.Net.Enums;
 using Polymarket.Net.Objects;
-using CryptoExchange.Net.Objects.Errors;
+using Polymarket.Net.Objects.Options;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Polymarket.Net.UnitTests
 {
@@ -72,6 +74,13 @@ namespace Polymarket.Net.UnitTests
             await RunAndCheckResult(client => client.ClobApi.ExchangeData.GetFeeRateBpsAsync(tokenId, default), false);
             await RunAndCheckResult(client => client.ClobApi.ExchangeData.GetLastTradePriceAsync(tokenId, default), false);
             await RunAndCheckResult(client => client.ClobApi.ExchangeData.GetLastTradePricesAsync(new[] { tokenId }, default), false);
+        }
+
+        [Test]
+        public async Task TestDataApi() {
+            var user = "0x0000000000000000000000000000000000000000";
+
+            await RunAndCheckResult(client => client.DataApi.GetPositionsAsync(user, default), false);
         }
     }
 }

--- a/Polymarket.Net.UnitTests/RestRequestTests.cs
+++ b/Polymarket.Net.UnitTests/RestRequestTests.cs
@@ -39,7 +39,7 @@ namespace Polymarket.Net.UnitTests
             var client = new PolymarketRestClient(null, loggerFactory, Options.Create(new PolymarketRestOptions
             {
                 AutoTimestamp = false,
-                Environment = PolymarketEnvironment.CreateCustom("UnitTest", 137, "https://clob.polymarket.com", "https://clob.polymarket.com", "wss://localhost", "wss://localhost"),
+                Environment = PolymarketEnvironment.CreateCustom("UnitTest", 137, "https://clob.polymarket.com", "https://clob.polymarket.com", "https://data-api.polymarket.com", "wss://localhost", "wss://localhost"),
                 ApiCredentials = new PolymarketCredentials().WithL1(Enums.SignType.Email, "0x1212121212121212121212121212121212121212121212121212121212121212").WithL2("MTIz", "MTIz", "12")
             }));
             var tester = new RestRequestValidator<PolymarketRestClient>(client, "Endpoints/Clob/Trading", "https://clob.polymarket.com", IsAuthenticated);

--- a/Polymarket.Net/Clients/DataApi/PolymarketRestClientDataApi.cs
+++ b/Polymarket.Net/Clients/DataApi/PolymarketRestClientDataApi.cs
@@ -1,0 +1,79 @@
+﻿using CryptoExchange.Net.Clients;
+using CryptoExchange.Net.Converters.MessageParsing.DynamicConverters;
+using CryptoExchange.Net.Converters.SystemTextJson;
+using CryptoExchange.Net.Interfaces;
+using CryptoExchange.Net.Objects;
+using CryptoExchange.Net.Objects.Errors;
+using CryptoExchange.Net.Objects.Options;
+using CryptoExchange.Net.SharedApis;
+using Microsoft.Extensions.Logging;
+using Polymarket.Net.Clients.MessageHandlers;
+using Polymarket.Net.Interfaces.Clients.DataApi;
+using Polymarket.Net.Objects.Models;
+using Polymarket.Net.Objects.Options;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Polymarket.Net.Clients.DataApi
+{
+    internal partial class PolymarketRestClientDataApi : RestApiClient<PolymarketEnvironment, PolymarketAuthenticationProvider, PolymarketCredentials>, IPolymarketRestClientDataApi
+    {
+        #region fields 
+        private static readonly RequestDefinitionCache _definitions = new RequestDefinitionCache();
+
+        protected override ErrorMapping ErrorMapping => PolymarketErrors.Errors;
+
+        public new PolymarketRestOptions ClientOptions => (PolymarketRestOptions)base.ClientOptions;
+
+        /// <inheritdoc />
+        protected override IRestMessageHandler MessageHandler { get; } = new PolymarketRestMessageHandler(PolymarketErrors.Errors);
+        #endregion
+
+        #region constructor/destructor
+        internal PolymarketRestClientDataApi(ILogger logger, HttpClient? httpClient, PolymarketRestOptions options)
+            : base(logger, httpClient, options.Environment.DataRestClientAddress, options, options.DataOptions) {
+            RequestBodyEmptyContent = "";
+            ArraySerialization = ArrayParametersSerialization.MultipleValues;
+
+            OrderParameters = false;
+        }
+        #endregion
+
+        /// <inheritdoc />
+        protected override IMessageSerializer CreateSerializer() => new SystemTextJsonMessageSerializer(PolymarketPlatform._serializerContext);
+
+        /// <inheritdoc />
+        protected override PolymarketAuthenticationProvider CreateAuthenticationProvider(PolymarketCredentials credentials)
+            => new PolymarketAuthenticationProvider(credentials);
+
+        internal Task<WebCallResult> SendAsync(RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null)
+            => SendToAddressAsync(BaseAddress, definition, parameters, cancellationToken, weight);
+
+        internal async Task<WebCallResult> SendToAddressAsync(string baseAddress, RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null) {
+            var result = await base.SendAsync(baseAddress, definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
+            return result;
+        }
+
+        internal Task<WebCallResult<T>> SendAsync<T>(RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null)
+            => SendToAddressAsync<T>(BaseAddress, definition, parameters, cancellationToken, weight);
+
+        internal async Task<WebCallResult<T>> SendToAddressAsync<T>(string baseAddress, RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null) {
+            var result = await base.SendAsync<T>(baseAddress, definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
+            return result;
+        }
+
+        /// <inheritdoc />
+        public override string FormatSymbol(string baseAsset, string quoteAsset, TradingMode tradingMode, DateTime? deliverDate = null)
+            => throw new NotImplementedException();
+
+        public async Task<WebCallResult<PolymarketPosition[]>> GetPositionsAsync(string user, CancellationToken ct = default) {
+            var request = _definitions.GetOrCreate(HttpMethod.Get, $"positions?user={user}", PolymarketPlatform.RateLimiter.DataApi, 1, false);
+            return await SendAsync<PolymarketPosition[]>(request, null, ct).ConfigureAwait(false);
+        }
+    }
+}

--- a/Polymarket.Net/Clients/PolymarketRestClient.cs
+++ b/Polymarket.Net/Clients/PolymarketRestClient.cs
@@ -1,17 +1,19 @@
-using Microsoft.Extensions.Logging;
-using System.Net.Http;
-using System;
 using CryptoExchange.Net.Authentication;
-using Polymarket.Net.Interfaces.Clients;
-using Polymarket.Net.Objects.Options;
 using CryptoExchange.Net.Clients;
-using Microsoft.Extensions.Options;
 using CryptoExchange.Net.Objects.Options;
-using Polymarket.Net.Interfaces.Clients.ClobApi;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Polymarket.Net.Clients.ClobApi;
-using Polymarket.Net.Interfaces.Clients.GammaApi;
 using Polymarket.Net.Clients.GammaApi;
+using Polymarket.Net.Interfaces.Clients;
+using Polymarket.Net.Interfaces.Clients.ClobApi;
+using Polymarket.Net.Interfaces.Clients.GammaApi;
 using Polymarket.Net.Objects.Models;
+using Polymarket.Net.Objects.Options;
+using System;
+using System.Net.Http;
+using Polymarket.Net.Interfaces.Clients.DataApi;
+using Polymarket.Net.Clients.DataApi;
 
 namespace Polymarket.Net.Clients
 {
@@ -25,6 +27,9 @@ namespace Polymarket.Net.Clients
 
         /// <inheritdoc />
         public IPolymarketRestClientGammaApi GammaApi { get; }
+
+        /// <inheritdoc />
+        public IPolymarketRestClientDataApi DataApi { get; }
 
         #endregion
 
@@ -51,6 +56,7 @@ namespace Polymarket.Net.Clients
             
             ClobApi = AddApiClient(new PolymarketRestClientClobApi(_logger, httpClient, options.Value));
             GammaApi = AddApiClient(new PolymarketRestClientGammaApi(_logger, httpClient, options.Value));
+            DataApi = AddApiClient(new PolymarketRestClientDataApi(_logger, httpClient, options.Value));
         }
 
         #endregion

--- a/Polymarket.Net/Converters/PolymarketSourceGenerationContext.cs
+++ b/Polymarket.Net/Converters/PolymarketSourceGenerationContext.cs
@@ -82,6 +82,9 @@ namespace Polymarket.Net.Converters
     [JsonSerializable(typeof(decimal?))]
     [JsonSerializable(typeof(DateTime))]
     [JsonSerializable(typeof(DateTime?))]
+
+    [JsonSerializable(typeof(PolymarketPosition[]))]
+
     internal partial class PolymarketSourceGenerationContext : JsonSerializerContext
     {
     }

--- a/Polymarket.Net/Interfaces/Clients/DataApi/IPolymarketRestClientDataApi.cs
+++ b/Polymarket.Net/Interfaces/Clients/DataApi/IPolymarketRestClientDataApi.cs
@@ -1,0 +1,28 @@
+﻿using CryptoExchange.Net.Interfaces.Clients;
+using CryptoExchange.Net.Objects;
+using Polymarket.Net.Objects.Models;
+using Polymarket.Net.Objects.Options;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Polymarket.Net.Interfaces.Clients.DataApi
+{
+    /// <summary>
+    /// Polymarket Data API endpoints
+    /// </summary>
+    public interface IPolymarketRestClientDataApi : IRestApiClient<PolymarketCredentials>, IDisposable
+    {
+        /// <summary>
+        /// Get list of all positions for a user
+        /// /// <para>
+        /// Endpoint:<br />
+        /// GET /positions
+        /// </para>
+        /// </summary>
+        /// <param name="user">["<c>user</c>"] By user</param>
+        /// <param name="ct"></param>
+        /// <returns></returns>
+        Task<WebCallResult<PolymarketPosition[]>> GetPositionsAsync(string user, CancellationToken ct = default);
+    }
+}

--- a/Polymarket.Net/Objects/Models/PolymarketPosition.cs
+++ b/Polymarket.Net/Objects/Models/PolymarketPosition.cs
@@ -1,0 +1,167 @@
+﻿using System;
+using System.Text.Json.Serialization;
+
+namespace Polymarket.Net.Objects.Models
+{
+    /// <summary>
+    /// Positions info
+    /// </summary>
+    public record PolymarketPosition
+    {
+        /// <summary>
+        /// ["<c>proxyWallet</c>"] ProxyWallet
+        /// </summary>
+        [JsonPropertyName("proxyWallet")]
+        public string ProxyWallet { get; set; } = string.Empty;
+
+        /// <summary>
+        /// ["<c>asset</c>"] Asset
+        /// </summary>
+        [JsonPropertyName("asset")]
+        public string Asset { get; set; } = string.Empty;
+
+        /// <summary>
+        /// ["<c>conditionId</c>"] ConditionId
+        /// </summary>
+        [JsonPropertyName("conditionId")]
+        public string ConditionId { get; set; } = String.Empty;
+
+        /// <summary>
+        /// ["<c>size</c>"] Size
+        /// </summary>
+        [JsonPropertyName("size")]
+        public decimal Size { get; set; }
+
+        /// <summary>
+        /// ["<c>avgPrice</c>"] AvgPrice
+        /// </summary>
+        [JsonPropertyName("avgPrice")]
+        public decimal AvgPrice { get; set; }
+
+        /// <summary>
+        /// ["<c>initialValue</c>"] InitialValue
+        /// </summary>
+        [JsonPropertyName("initialValue")]
+        public decimal InitialValue { get; set; }
+
+        /// <summary>
+        /// ["<c>currentValue</c>"] CurrentValue
+        /// </summary>
+        [JsonPropertyName("currentValue")]
+        public decimal CurrentValue { get; set; }
+
+        /// <summary>
+        /// ["<c>cashPnl</c>"] CashPnl
+        /// </summary>
+        [JsonPropertyName("cashPnl")]
+        public decimal CashPnl { get; set; }
+
+        /// <summary>
+        /// ["<c>percentPnl</c>"] PercentPnl
+        /// </summary>
+        [JsonPropertyName("percentPnl")]
+        public decimal PercentPnl { get; set; }
+
+        /// <summary>
+        /// ["<c>totalBought</c>"] TotalBought
+        /// </summary>
+        [JsonPropertyName("totalBought")]
+        public decimal TotalBought { get; set; }
+
+        /// <summary>
+        /// ["<c>totalSold</c>"] TotalSold
+        /// </summary>
+        [JsonPropertyName("realizedPnl")]
+        public decimal RealizedPnl { get; set; }
+
+        /// <summary>
+        /// ["<c>percentRealizedPnl</c>"] PercentRealizedPnl
+        /// </summary>
+        [JsonPropertyName("percentRealizedPnl")]
+        public decimal PercentRealizedPnl { get; set; }
+
+        /// <summary>
+        /// ["<c>curPrice</c>"] CurPrice
+        /// </summary>
+        [JsonPropertyName("curPrice")]
+        public decimal CurPrice { get; set; }
+
+        /// <summary>
+        /// ["<c>redeemable</c>"] Redeemable
+        /// </summary>
+        [JsonPropertyName("redeemable")]
+        public bool Redeemable { get; set; }
+
+        /// <summary>
+        /// ["<c>mergeable</c>"] Mergeable
+        /// </summary>
+        [JsonPropertyName("mergeable")]
+        public bool Mergeable { get; set; }
+
+        /// <summary>
+        /// ["<c>title</c>"] Title
+        /// </summary>
+        [JsonPropertyName("title")]
+        public string Title { get; set; } = string.Empty;
+
+        /// <summary>
+        /// ["<c>slug</c>"] Slug
+        /// </summary>
+        [JsonPropertyName("slug")]
+        public string Slug { get; set; } = string.Empty;
+
+        /// <summary>
+        /// ["<c>icon</c>"] Icon
+        /// </summary>
+        [JsonPropertyName("icon")]
+        public string Icon { get; set; } = string.Empty;
+
+        /// <summary>
+        /// ["<c>eventId</c>"] EventId
+        /// </summary>
+        [JsonPropertyName("eventId")]
+        public string EventId { get; set; } = string.Empty;
+
+        /// <summary>
+        /// ["<c>eventSlug</c>"] EventSlug
+        /// </summary>
+        [JsonPropertyName("eventSlug")]
+        public string EventSlug { get; set; } = string.Empty;
+
+        /// <summary>
+        /// ["<c>outcome</c>"] Outcome
+        /// </summary>
+        [JsonPropertyName("outcome")]
+        public string Outcome { get; set; } = string.Empty;
+
+        /// <summary>
+        /// ["<c>outcomeIndex</c>"] OutcomeIndex
+        /// </summary>
+        [JsonPropertyName("outcomeIndex")]
+        public int OutcomeIndex { get; set; }
+
+        /// <summary>
+        /// ["<c>oppositeOutcome</c>"] OppositeOutcome
+        /// </summary>
+        [JsonPropertyName("oppositeOutcome")]
+        public string OppositeOutcome { get; set; } = string.Empty;
+
+        /// <summary>
+        /// ["<c>oppositeAsset</c>"] OppositeAsset
+        /// </summary>
+        [JsonPropertyName("oppositeAsset")]
+        public string OppositeAsset { get; set; } = string.Empty;
+
+        /// <summary>
+        /// ["<c>createdDate</c>"] CreatedDate
+        /// </summary>
+        [JsonPropertyName("endDate")]
+        public string EndDate { get; set; } = string.Empty;
+
+        /// <summary>
+        /// ["<c>negativeRisk</c>"] NegativeRisk
+        /// </summary>
+        [JsonPropertyName("negativeRisk")]
+        public bool NegativeRisk { get; set; }
+    }
+}

--- a/Polymarket.Net/Objects/Options/PolymarketRestOptions.cs
+++ b/Polymarket.Net/Objects/Options/PolymarketRestOptions.cs
@@ -35,6 +35,11 @@ namespace Polymarket.Net.Objects.Options
         public RestApiOptions GammaOptions { get; private set; } = new RestApiOptions();
 
         /// <summary>
+        /// Data API options
+        /// </summary>
+        public RestApiOptions DataOptions { get; private set; } = new RestApiOptions();
+
+        /// <summary>
         /// Builder API api key
         /// </summary>
         public string? BuilderApiKey { get; set; }

--- a/Polymarket.Net/Objects/PolymarketApiAddresses.cs
+++ b/Polymarket.Net/Objects/PolymarketApiAddresses.cs
@@ -14,10 +14,17 @@ namespace Polymarket.Net.Objects
         /// The address used by the PolymarketRestClient for the Gamma API
         /// </summary>
         public string GammaRestClientAddress { get; set; } = "";
+
+        /// <summary>
+        /// The address used by the PolymarketRestClient for the Data API
+        /// </summary>
+        public string DataRestClientAddress { get; set; } = "";
+
         /// <summary>
         /// The address used by the PolymarketSocketClient for the Clob websocket API
         /// </summary>
         public string ClobSocketClientAddress { get; set; } = "";
+
         /// <summary>
         /// The address used by the PolymarketSocketClient for the Sport websocket API
         /// </summary>
@@ -30,6 +37,7 @@ namespace Polymarket.Net.Objects
         {
             ClobRestClientAddress = "https://clob.polymarket.com",
             GammaRestClientAddress = "https://gamma-api.polymarket.com",
+            DataRestClientAddress = "https://data-api.polymarket.com",
             ClobSocketClientAddress = "wss://ws-subscriptions-clob.polymarket.com",
             SportsSocketClientAddress = "wss://sports-api.polymarket.com"
         };

--- a/Polymarket.Net/PolymarketEnvironment.cs
+++ b/Polymarket.Net/PolymarketEnvironment.cs
@@ -18,10 +18,16 @@ namespace Polymarket.Net
         /// Rest Clob API address
         /// </summary>
         public string ClobRestClientAddress { get; }
+        
         /// <summary>
         /// Rest Gamma API address
         /// </summary>
         public string GammaRestClientAddress { get; }
+
+        /// <summary>
+        /// Rest Data API address
+        /// </summary>
+        public string DataRestClientAddress { get; }
 
         /// <summary>
         /// Socket Clob API address
@@ -38,6 +44,7 @@ namespace Polymarket.Net
             uint chainId,
             string clobRestAddress,
             string gammaRestAddress,
+            string dataRestAddress,
             string clobStreamAddress,
             string sportStreamAddress) :
             base(name)
@@ -45,6 +52,7 @@ namespace Polymarket.Net
             ChainId = chainId;
             ClobRestClientAddress = clobRestAddress;
             GammaRestClientAddress = gammaRestAddress;
+            DataRestClientAddress = dataRestAddress;
             ClobSocketClientAddress = clobStreamAddress;
             SportSocketClientAddress = sportStreamAddress;
         }
@@ -84,6 +92,7 @@ namespace Polymarket.Net
                                      137,
                                      PolymarketApiAddresses.Default.ClobRestClientAddress,
                                      PolymarketApiAddresses.Default.GammaRestClientAddress,
+                                     PolymarketApiAddresses.Default.DataRestClientAddress,
                                      PolymarketApiAddresses.Default.ClobSocketClientAddress,
                                      PolymarketApiAddresses.Default.SportsSocketClientAddress);
 
@@ -95,6 +104,7 @@ namespace Polymarket.Net
                                      80002,
                                      PolymarketApiAddresses.Default.ClobRestClientAddress,
                                      PolymarketApiAddresses.Default.GammaRestClientAddress,
+                                     PolymarketApiAddresses.Default.DataRestClientAddress,
                                      PolymarketApiAddresses.Default.ClobSocketClientAddress,
                                      PolymarketApiAddresses.Default.SportsSocketClientAddress);
 
@@ -107,8 +117,9 @@ namespace Polymarket.Net
                         uint chainId,
                         string clobRestAddress,
                         string gammaRestAddress,
+                        string dataRestAddress,
                         string clobSocketStreamsAddress,
                         string sportSocketStreamsAddress)
-            => new PolymarketEnvironment(name, chainId, clobRestAddress, gammaRestAddress, clobSocketStreamsAddress, sportSocketStreamsAddress);
+            => new PolymarketEnvironment(name, chainId, clobRestAddress, gammaRestAddress, dataRestAddress, clobSocketStreamsAddress, sportSocketStreamsAddress);
     }
 }

--- a/Polymarket.Net/PolymarketPlatform.cs
+++ b/Polymarket.Net/PolymarketPlatform.cs
@@ -68,14 +68,20 @@ namespace Polymarket.Net
             GammaApi = new RateLimitGate("Gamma")
                 .AddGuard(new RateLimitGuard(RateLimitGuard.PerHost, new LimitItemTypeFilter(RateLimitItemType.Request), 1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding)); // 1000 requests per 10 seconds
 
+            DataApi = new RateLimitGate("Data")
+                .AddGuard(new RateLimitGuard(RateLimitGuard.PerHost, new LimitItemTypeFilter(RateLimitItemType.Request), 1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding)); // 1000 requests per 10 seconds
+
             ClobApi.RateLimitTriggered += (x) => RateLimitTriggered?.Invoke(x);
             ClobApi.RateLimitUpdated += (x) => RateLimitUpdated?.Invoke(x);
             GammaApi.RateLimitTriggered += (x) => RateLimitTriggered?.Invoke(x);
             GammaApi.RateLimitUpdated += (x) => RateLimitUpdated?.Invoke(x);
+            DataApi.RateLimitTriggered += (x) => RateLimitTriggered?.Invoke(x);
+            DataApi.RateLimitUpdated += (x) => RateLimitUpdated?.Invoke(x);
         }
 
 
         internal IRateLimitGate ClobApi { get; private set; }
         internal IRateLimitGate GammaApi { get; private set; }
+        internal IRateLimitGate DataApi { get; private set; }
     }
 }


### PR DESCRIPTION
Added IPolymarketRestClientDataApi interface and implementation for accessing the Data API, including the GetPositionsAsync method for retrieving user positions. DataApi is now registered in PolymarketRestClient and configurable via PolymarketRestOptions, PolymarketApiAddresses and PolymarketEnvironment. Added rate limiting for Data API in PolymarketPlatform. Added PolymarketPosition model and serialization support in PolymarketSourceGenerationContext. Updated integration tests and RestRequestTests for new functionality. Made adjustments to code organization and directives for better Data API support.