### PR TITLE
Add place market order methods - Fix market buy order calculation flaw

### DIFF
--- a/Polymarket.Net/Clients/ClobApi/PolymarketRestClientClobApiTrading.cs
+++ b/Polymarket.Net/Clients/ClobApi/PolymarketRestClientClobApiTrading.cs
@@ -52,10 +52,6 @@ namespace Polymarket.Net.Clients.ClobApi
             _logger = logger;
         }
 
-
-
-
-
 		/// <summary>
         /// Places a new limit order to the Polymarket platform asynchronously using the specified order request parameters.
         /// </summary>
@@ -89,7 +85,6 @@ namespace Polymarket.Net.Clients.ClobApi
 			return await SendOrderAsync(parameters, ct).ConfigureAwait(false);
 		}
 
-
 		/// <summary>
 		/// Places a new market order to the Polymarket platform asynchronously using the specified order request parameters.
 		/// </summary>
@@ -120,14 +115,19 @@ namespace Polymarket.Net.Clients.ClobApi
 				null);
 
 			return await SendOrderAsync(parameters, ct).ConfigureAwait(false);
-		}        
+		}
 
         /// <summary>
-        /// 
+        /// Places multiple limit orders asynchronously based on the specified order requests.
         /// </summary>
-        /// <param name="requests"></param>
-        /// <param name="ct"></param>
-        /// <returns></returns>
+        /// <remarks>If all orders fail, the returned data will indicate the failure for each order.
+        /// Partial success is possible; callers should inspect each CallResult in the returned array to determine the
+        /// status of individual orders.</remarks>
+        /// <param name="requests">A collection of limit order requests to be placed. Each request specifies the order details such as token,
+        /// side, quantity (number of shares), and additional order parameters.</param>
+        /// <param name="ct">A cancellation token that can be used to cancel the operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains a WebCallResult with an array of
+        /// CallResult objects, each representing the outcome of an individual limit order request.</returns>
         public async Task<WebCallResult<CallResult<PolymarketOrderResult>[]>> PlaceMultipleOrdersAsync(IEnumerable<PolymarketOrderRequest> requests, CancellationToken ct = default)
         {
             var parameterList = new List<ParameterCollection>();
@@ -173,6 +173,17 @@ namespace Polymarket.Net.Clients.ClobApi
             return result.As(ordersResult.ToArray());
         }
 
+        /// <summary>
+        /// Places multiple market orders asynchronously based on the specified order requests.
+        /// </summary>
+        /// <remarks>If all orders fail, the returned data will indicate the failure for each order.
+        /// Partial success is possible; callers should inspect each CallResult in the returned array to determine the
+        /// status of individual orders.</remarks>
+        /// <param name="requests">A collection of market order requests to be placed. Each request specifies the order details such as token,
+        /// side, amount (BUY = USDC spend amount, SELL = asset/shares amount), and additional order parameters.</param>
+        /// <param name="ct">A cancellation token that can be used to cancel the operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains a WebCallResult with an array of
+        /// CallResult objects, each representing the outcome of an individual market order request.</returns>
         public async Task<WebCallResult<CallResult<PolymarketOrderResult>[]>> PlaceMultipleMarketOrdersAsync(IEnumerable<PolymarketMarketOrderRequest> requests, CancellationToken ct = default)
         {
             var parameterList = new List<ParameterCollection>();

--- a/Polymarket.Net/Clients/ClobApi/PolymarketRestClientClobApiTrading.cs
+++ b/Polymarket.Net/Clients/ClobApi/PolymarketRestClientClobApiTrading.cs
@@ -3,6 +3,7 @@ using CryptoExchange.Net.Converters.SystemTextJson;
 using CryptoExchange.Net.Objects;
 using CryptoExchange.Net.Objects.Errors;
 using CryptoExchange.Net.RateLimiting.Guards;
+using CryptoExchange.Net.Requests;
 using CryptoExchange.Net.SharedApis;
 using Microsoft.Extensions.Logging;
 using Polymarket.Net.Enums;
@@ -51,67 +52,82 @@ namespace Polymarket.Net.Clients.ClobApi
             _logger = logger;
         }
 
-        public async Task<WebCallResult<PolymarketOrderResult>> PlaceOrderAsync(
-            string tokenId,
-            OrderSide side,
-            OrderType orderType,
-            decimal quantity, // <-- MARKET BUY: USDC amount, MARKET SELL: asset amount, LIMIT BUY: asset amount, LIMIT SELL: asset amount
-			decimal? price = null,
-            TimeInForce? timeInForce = null,
-            bool? postOnly = null,
-            long? feeRateBps = null,
-            string? takerAddress = null,
-            long? clientOrderId = null,
-            DateTime? expiration = null,
-            long? nonce = null,
-            CancellationToken ct = default)
-        {
-            var tokenResult = await PolymarketUtils.GetTokenInfoAsync(tokenId, _baseClient).ConfigureAwait(false);
-            if (!tokenResult)
-                return new WebCallResult<PolymarketOrderResult>(tokenResult.Error);
 
-            var makerTakerQuantities = await GetMakerTakerQuantitiesAsync(tokenId, side, orderType, quantity, price, timeInForce, tokenResult.Data.TickQuantity).ConfigureAwait(false);
-            if (!makerTakerQuantities)
-                return new WebCallResult<PolymarketOrderResult>(makerTakerQuantities.Error);
 
-            var parameters = new ParameterCollection();
-            var orderParameters = new ParameterCollection();
-            var credentials = _baseClient.AuthenticationProvider!.ApiCredentials;
-            orderParameters.Add("salt", (ulong)(clientOrderId ?? ExchangeHelpers.RandomLong(1000000000000, 9999999999999)));
-            orderParameters.Add("maker", credentials.L1.PolymarketFundingAddress ?? credentials.L1.GetPublicAddress());
-            orderParameters.Add("signer", credentials.L1.GetPublicAddress());
-            orderParameters.Add("taker", takerAddress ?? "0x0000000000000000000000000000000000000000");
-            orderParameters.Add("tokenId", tokenId);
-            orderParameters.AddString("makerAmount", makerTakerQuantities.Data.MakerQuantity);
-            orderParameters.AddString("takerAmount", makerTakerQuantities.Data.TakerQuantity);
-            orderParameters.AddString("expiration", (ulong)(expiration == null ? 0 : DateTimeConverter.ConvertToSeconds(expiration.Value)));
-            orderParameters.AddString("nonce", nonce ?? 0);
-            orderParameters.AddString("feeRateBps", feeRateBps ?? 0);
-            orderParameters.AddEnum("side", side);
-            orderParameters.Add("signatureType", (int)credentials.L1.SignType);
-            orderParameters.Add("signature", 
-                _baseClient.AuthenticationProvider.GetOrderSignature(
-                    orderParameters,
-                    _baseClient.ClientOptions.Environment.ChainId,
-                    tokenResult.Data.NegativeRisk).ToLowerInvariant());
 
-            parameters.Add("order", orderParameters);
-            parameters.Add("owner", credentials.L2!.Key!);
-            parameters.AddEnum("orderType", timeInForce ?? (orderType == OrderType.Limit ? TimeInForce.GoodTillCanceled : TimeInForce.ImmediateOrCancel));
-            parameters.AddOptional("postOnly", postOnly);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/order", PolymarketPlatform.RateLimiter.ClobApi, 1, true,
-                limitGuard: new SingleLimitGuard(3500, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
-            var result = await _baseClient.SendAsync<PolymarketOrderResult>(request, parameters, ct).ConfigureAwait(false);
 
-            if (!result)
-                return result;
+		/// <summary>
+        /// Places a new limit order to the Polymarket platform asynchronously using the specified order request parameters.
+        /// </summary>
+        /// <remarks>The method validates the provided order request and retrieves necessary token and
+        /// quantity information before submitting the order. If validation fails or required data cannot be retrieved,
+        /// the result will contain error information. The caller should check the returned WebCallResult for success or
+        /// failure and handle errors appropriately.</remarks>
+        /// <param name="request">An object containing the details of the order to be placed, including token information, side, quantity (number of shares),
+        /// price, and time in force. Cannot be null.</param>
+        /// <param name="ct">A cancellation token that can be used to cancel the asynchronous operation.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains a WebCallResult with the result
+        /// of the order placement, including order details if successful or error information if the operation fails.</returns>
+		public async Task<WebCallResult<PolymarketOrderResult>> PlaceOrderAsync(
+			PolymarketOrderRequest request,
+			CancellationToken ct = default)
+		{
+			var tokenResult = await PolymarketUtils.GetTokenInfoAsync(request.TokenId, _baseClient).ConfigureAwait(false);
+			if (!tokenResult)
+				return new WebCallResult<PolymarketOrderResult>(tokenResult.Error);
 
-            if (!string.IsNullOrEmpty(result.Data.Error))
-                return result.AsError<PolymarketOrderResult>(new ServerError(_baseClient.GetErrorInfo(result.Data.Error!, result.Data.Error)));
+			var makerTakerQuantities = await GetMakerTakerQuantitiesAsync(request.TokenId, request.Side, OrderType.Limit, request.Quantity, request.Price, request.TimeInForce, tokenResult.Data.TickQuantity).ConfigureAwait(false);
+			if (!makerTakerQuantities)
+				return new WebCallResult<PolymarketOrderResult>(makerTakerQuantities.Error);
 
-            return result;
-        }
+			var parameters = BuildOrderParameters(
+		        request.TokenId, request.Side, makerTakerQuantities.Data.MakerQuantity, makerTakerQuantities.Data.TakerQuantity,
+		        tokenResult.Data.NegativeRisk, request.TakerAddress, request.ClientOrderId, request.Expiration, request.Nonce, request.FeeRateBps,
+		        request.TimeInForce ?? TimeInForce.GoodTillCanceled,
+		        null);
 
+			return await SendOrderAsync(parameters, ct).ConfigureAwait(false);
+		}
+
+
+		/// <summary>
+		/// Places a new market order to the Polymarket platform asynchronously using the specified order request parameters.
+		/// </summary>
+		/// <remarks>The method validates the provided token information and calculates maker and taker
+		/// quantities before submitting the order. If validation fails, the result will contain error details. The
+		/// operation is performed asynchronously and can be cancelled using the provided cancellation token.</remarks>
+		/// <param name="request">The market order request containing details such as token ID, side, amount (BUY = USDC spend amount, SELL = asset/shares amount), and other order parameters.
+		/// Cannot be null.</param>
+		/// <param name="ct">A cancellation token that can be used to cancel the asynchronous operation.</param>
+		/// <returns>A task that represents the asynchronous operation. The task result contains a WebCallResult with the result
+		/// of the placed market order, or error information if the operation fails.</returns>
+		public async Task<WebCallResult<PolymarketOrderResult>> PlaceMarketOrderAsync(
+			PolymarketMarketOrderRequest request,
+			CancellationToken ct = default)
+		{
+			var tokenResult = await PolymarketUtils.GetTokenInfoAsync(request.TokenId, _baseClient).ConfigureAwait(false);
+			if (!tokenResult)
+				return new WebCallResult<PolymarketOrderResult>(tokenResult.Error);
+
+			var makerTakerQuantities = await GetMakerTakerQuantitiesAsync(request.TokenId, request.Side, OrderType.Market, request.Amount, null, request.TimeInForce, tokenResult.Data.TickQuantity).ConfigureAwait(false);
+			if (!makerTakerQuantities)
+				return new WebCallResult<PolymarketOrderResult>(makerTakerQuantities.Error);
+
+			var parameters = BuildOrderParameters(
+				request.TokenId, request.Side, makerTakerQuantities.Data.MakerQuantity, makerTakerQuantities.Data.TakerQuantity,
+				tokenResult.Data.NegativeRisk, request.TakerAddress, request.ClientOrderId, request.Expiration, request.Nonce, request.FeeRateBps,
+				request.TimeInForce ?? TimeInForce.ImmediateOrCancel,
+				null);
+
+			return await SendOrderAsync(parameters, ct).ConfigureAwait(false);
+		}        
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="requests"></param>
+        /// <param name="ct"></param>
+        /// <returns></returns>
         public async Task<WebCallResult<CallResult<PolymarketOrderResult>[]>> PlaceMultipleOrdersAsync(IEnumerable<PolymarketOrderRequest> requests, CancellationToken ct = default)
         {
             var parameterList = new List<ParameterCollection>();
@@ -121,35 +137,16 @@ namespace Polymarket.Net.Clients.ClobApi
                 if (!tokenResult)
                     return new WebCallResult<CallResult<PolymarketOrderResult>[]>(tokenResult.Error);
 
-                var makerTakerQuantities = await GetMakerTakerQuantitiesAsync(request.TokenId, request.Side, request.OrderType, request.Quantity, request.Price, request.TimeInForce, tokenResult.Data.TickQuantity).ConfigureAwait(false);
+                var makerTakerQuantities = await GetMakerTakerQuantitiesAsync(request.TokenId, request.Side, OrderType.Limit, request.Quantity, request.Price, request.TimeInForce, tokenResult.Data.TickQuantity).ConfigureAwait(false);
                 if (!makerTakerQuantities)
                     return new WebCallResult<CallResult<PolymarketOrderResult>[]>(makerTakerQuantities.Error);
 
-                var parameters = new ParameterCollection();
-                var orderParameters = new ParameterCollection();
-                var credentials = _baseClient.AuthenticationProvider!.ApiCredentials;
-                orderParameters.Add("salt", (ulong)(request.ClientOrderId ?? ExchangeHelpers.RandomLong(1000000000000, 9999999999999)));
-                orderParameters.Add("maker", credentials.L1.PolymarketFundingAddress ?? credentials.L1.GetPublicAddress());
-                orderParameters.Add("signer", credentials.L1.GetPublicAddress());
-                orderParameters.Add("taker", request.TakerAddress ?? "0x0000000000000000000000000000000000000000");
-                orderParameters.Add("tokenId", request.TokenId);
-                orderParameters.AddString("makerAmount", makerTakerQuantities.Data.MakerQuantity);
-                orderParameters.AddString("takerAmount", makerTakerQuantities.Data.TakerQuantity);
-                orderParameters.AddString("expiration", (ulong)(request.Expiration == null ? 0 : DateTimeConverter.ConvertToSeconds(request.Expiration.Value)));
-                orderParameters.AddString("nonce", request.Nonce ?? 0);
-                orderParameters.AddString("feeRateBps", request.FeeRateBps ?? 0);
-                orderParameters.AddEnum("side", request.Side);
-                orderParameters.Add("signatureType", (int)credentials.L1.SignType);
-                orderParameters.Add("signature",
-                    _baseClient.AuthenticationProvider.GetOrderSignature(
-                        orderParameters,
-                        _baseClient.ClientOptions.Environment.ChainId,
-                        tokenResult.Data.NegativeRisk).ToLowerInvariant());
+                var parameters = BuildOrderParameters(
+                    request.TokenId, request.Side, makerTakerQuantities.Data.MakerQuantity, makerTakerQuantities.Data.TakerQuantity,
+                    tokenResult.Data.NegativeRisk, request.TakerAddress, request.ClientOrderId, request.Expiration, request.Nonce, request.FeeRateBps,
+                    request.TimeInForce ?? TimeInForce.GoodTillCanceled,
+                    request.PostOnly);
 
-                parameters.Add("order", orderParameters);
-                parameters.Add("owner", credentials.L2!.Key!);
-                parameters.AddEnum("orderType", request.TimeInForce ?? TimeInForce.GoodTillCanceled);
-                parameters.AddOptional("postOnly", request.PostOnly);
                 parameterList.Add(parameters);
             }
 
@@ -174,6 +171,108 @@ namespace Polymarket.Net.Clients.ClobApi
                 return result.AsErrorWithData(new ServerError(new ErrorInfo(ErrorType.AllOrdersFailed, "All orders failed")), ordersResult.ToArray());
 
             return result.As(ordersResult.ToArray());
+        }
+
+        public async Task<WebCallResult<CallResult<PolymarketOrderResult>[]>> PlaceMultipleMarketOrdersAsync(IEnumerable<PolymarketMarketOrderRequest> requests, CancellationToken ct = default)
+        {
+            var parameterList = new List<ParameterCollection>();
+            foreach (var request in requests)
+            {
+                var tokenResult = await PolymarketUtils.GetTokenInfoAsync(request.TokenId, _baseClient).ConfigureAwait(false);
+                if (!tokenResult)
+                    return new WebCallResult<CallResult<PolymarketOrderResult>[]>(tokenResult.Error);
+
+                var makerTakerQuantities = await GetMakerTakerQuantitiesAsync(request.TokenId, request.Side, OrderType.Market, request.Amount, null, request.TimeInForce, tokenResult.Data.TickQuantity).ConfigureAwait(false);
+                if (!makerTakerQuantities)
+                    return new WebCallResult<CallResult<PolymarketOrderResult>[]>(makerTakerQuantities.Error);
+
+                var parameters = BuildOrderParameters(
+                    request.TokenId, request.Side, makerTakerQuantities.Data.MakerQuantity, makerTakerQuantities.Data.TakerQuantity,
+                    tokenResult.Data.NegativeRisk, request.TakerAddress, request.ClientOrderId, request.Expiration, request.Nonce, request.FeeRateBps,
+                    request.TimeInForce ?? TimeInForce.ImmediateOrCancel,
+                    null);
+
+                parameterList.Add(parameters);
+            }
+
+            var requestParams = new ParameterCollection();
+            requestParams.SetBody(parameterList.ToArray());
+            var requestDef = _definitions.GetOrCreate(HttpMethod.Post, "/orders", PolymarketPlatform.RateLimiter.ClobApi, 1, true,
+                limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
+            var result = await _baseClient.SendAsync<PolymarketOrderResult[]>(requestDef, requestParams, ct).ConfigureAwait(false);
+            if (!result)
+                return result.As<CallResult<PolymarketOrderResult>[]>(default);
+
+            var ordersResult = new List<CallResult<PolymarketOrderResult>>();
+            foreach (var item in result.Data)
+            {
+                if (!string.IsNullOrEmpty(item.Error))
+                    ordersResult.Add(new CallResult<PolymarketOrderResult>(item, null, new ServerError(_baseClient.GetErrorInfo(item.Error!, item.Error))));
+                else
+                    ordersResult.Add(new CallResult<PolymarketOrderResult>(item));
+            }
+
+            if (ordersResult.All(x => !x.Success))
+                return result.AsErrorWithData(new ServerError(new ErrorInfo(ErrorType.AllOrdersFailed, "All orders failed")), ordersResult.ToArray());
+
+            return result.As(ordersResult.ToArray());
+        }
+
+        private ParameterCollection BuildOrderParameters(
+            string tokenId,
+            OrderSide side,
+            decimal makerQuantity,
+            decimal takerQuantity,
+            bool negativeRisk,
+            string? takerAddress,
+            long? clientOrderId,
+            DateTime? expiration,
+            long? nonce,
+            long? feeRateBps,
+            TimeInForce timeInForce,
+            bool? postOnly)
+        {
+            var parameters = new ParameterCollection();
+            var orderParameters = new ParameterCollection();
+            var credentials = _baseClient.AuthenticationProvider!.ApiCredentials;
+            orderParameters.Add("salt", (ulong)(clientOrderId ?? ExchangeHelpers.RandomLong(1000000000000, 9999999999999)));
+            orderParameters.Add("maker", credentials.L1.PolymarketFundingAddress ?? credentials.L1.GetPublicAddress());
+            orderParameters.Add("signer", credentials.L1.GetPublicAddress());
+            orderParameters.Add("taker", takerAddress ?? "0x0000000000000000000000000000000000000000");
+            orderParameters.Add("tokenId", tokenId);
+            orderParameters.AddString("makerAmount", makerQuantity);
+            orderParameters.AddString("takerAmount", takerQuantity);
+            orderParameters.AddString("expiration", (ulong)(expiration == null ? 0 : DateTimeConverter.ConvertToSeconds(expiration.Value)));
+            orderParameters.AddString("nonce", nonce ?? 0);
+            orderParameters.AddString("feeRateBps", feeRateBps ?? 0);
+            orderParameters.AddEnum("side", side);
+            orderParameters.Add("signatureType", (int)credentials.L1.SignType);
+            orderParameters.Add("signature",
+                _baseClient.AuthenticationProvider.GetOrderSignature(
+                    orderParameters,
+                    _baseClient.ClientOptions.Environment.ChainId,
+                    negativeRisk).ToLowerInvariant());
+
+            parameters.Add("order", orderParameters);
+            parameters.Add("owner", credentials.L2!.Key!);
+            parameters.AddEnum("orderType", timeInForce);
+            parameters.AddOptional("postOnly", postOnly);
+            return parameters;
+        }
+
+        private async Task<WebCallResult<PolymarketOrderResult>> SendOrderAsync(ParameterCollection parameters, CancellationToken ct)
+        {
+            var request = _definitions.GetOrCreate(HttpMethod.Post, "/order", PolymarketPlatform.RateLimiter.ClobApi, 1, true,
+                limitGuard: new SingleLimitGuard(3500, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
+            var result = await _baseClient.SendAsync<PolymarketOrderResult>(request, parameters, ct).ConfigureAwait(false);
+
+            if (!result)
+                return result;
+
+            if (!string.IsNullOrEmpty(result.Data.Error))
+                return result.AsError<PolymarketOrderResult>(new ServerError(_baseClient.GetErrorInfo(result.Data.Error!, result.Data.Error)));
+
+            return result;
         }
 
         private async Task<CallResult<(decimal MakerQuantity, decimal TakerQuantity)>> GetMakerTakerQuantitiesAsync(string tokenId, OrderSide side, OrderType orderType, decimal quantity, decimal? price, TimeInForce? timeInForce, decimal tickSize)
@@ -242,45 +341,45 @@ namespace Polymarket.Net.Clients.ClobApi
             }
 
             price = Math.Round(price!.Value, rounding.Price).Normalize();
-            if (side == OrderSide.Buy)
-            {
-                if (orderType == OrderType.Market)
-                {
-					// Maker quantity is USDC spend for market buy orders and
-					// then used to calculate the taker quantity (asset amount).
+			if (side == OrderSide.Buy)
+			{
+				if (orderType == OrderType.Market)
+				{
+					// For market buy orders, quantity represents the USDC spend amount.
+					// makerQuantity = USDC amount (what the buyer gives)
 					makerQuantity = RoundDown(quantity, rounding.Size);
 
-					// Taker quantity is the asset amount for market buy orders
+					// takerQuantity = asset/token amount (what the buyer receives)
 					takerQuantity = makerQuantity / price.Value;
-                    if (GetDecimalPlaces(takerQuantity) > rounding.Amount)
-                    {
-                        takerQuantity = RoundUp(takerQuantity, rounding.Amount + 4);
-                        if (GetDecimalPlaces(takerQuantity) > rounding.Amount)
-                            takerQuantity = RoundDown(takerQuantity, rounding.Amount);
-                    }
-                }
-                else
-                {
-					// Taker quantity is the asset amount for limit buy orders
-					// and then used to calculate the maker quantity (USDC spend).
+					if (GetDecimalPlaces(takerQuantity) > rounding.Amount)
+					{
+						takerQuantity = RoundUp(takerQuantity, rounding.Amount + 4);
+						if (GetDecimalPlaces(takerQuantity) > rounding.Amount)
+							takerQuantity = RoundDown(takerQuantity, rounding.Amount);
+					}
+				}
+				else
+				{
+					// For limit buy orders, quantity represents the asset/shares amount.
+					// takerQuantity = asset amount (what the buyer receives)
 					takerQuantity = RoundDown(quantity, rounding.Size);
 
-					// Maker quantity is the USDC spend for limit buy orders
+					// makerQuantity = USDC spend (what the buyer gives)
 					makerQuantity = takerQuantity * price.Value;
 
-                    if (GetDecimalPlaces(makerQuantity) > rounding.Amount)
-                    {
-                        makerQuantity = RoundUp(makerQuantity, rounding.Amount + 4);
-                        if (GetDecimalPlaces(makerQuantity) > rounding.Amount)
-                            makerQuantity = RoundDown(makerQuantity, rounding.Amount);
-                    }
-                }
-            }
-            else
-            {
-				// For sell orders, maker quantity is the asset amount and taker quantity is the USDC amount
-				// regardless of order type and then used to calculate the other quantity based on the price. 
-				// This is because for sell orders, the user is always giving the asset and receiving USDC.
+					if (GetDecimalPlaces(makerQuantity) > rounding.Amount)
+					{
+						makerQuantity = RoundUp(makerQuantity, rounding.Amount + 4);
+						if (GetDecimalPlaces(makerQuantity) > rounding.Amount)
+							makerQuantity = RoundDown(makerQuantity, rounding.Amount);
+					}
+				}
+			}
+			else
+			{
+				// For sell orders, quantity is always the asset/shares amount regardless of order type.
+				// makerQuantity = asset amount (what the seller gives)
+				// takerQuantity = USDC amount (what the seller receives)
 				makerQuantity = RoundDown(quantity, rounding.Size);
                 takerQuantity = makerQuantity * price.Value;
 

--- a/Polymarket.Net/Clients/ClobApi/PolymarketRestClientClobApiTrading.cs
+++ b/Polymarket.Net/Clients/ClobApi/PolymarketRestClientClobApiTrading.cs
@@ -246,22 +246,28 @@ namespace Polymarket.Net.Clients.ClobApi
             {
                 if (orderType == OrderType.Market)
                 {
-                    takerQuantity = quantity;
-                    if (GetDecimalPlaces(takerQuantity) > rounding.Amount)
+					// Maker quantity is USDC spend for market buy orders and
+					// then used to calculate the taker quantity (asset amount).
+					makerQuantity = quantity;
+                    if (GetDecimalPlaces(makerQuantity) > rounding.Amount)
                     {
-                        takerQuantity = RoundUp(takerQuantity, rounding.Amount + 4);
-                        if (GetDecimalPlaces(takerQuantity) > rounding.Amount)
-                            takerQuantity = RoundDown(takerQuantity, rounding.Amount);
+                        makerQuantity = RoundUp(makerQuantity, rounding.Amount + 4);
+                        if (GetDecimalPlaces(makerQuantity) > rounding.Amount)
+                            makerQuantity = RoundDown(makerQuantity, rounding.Amount);
                     }
 
-                    makerQuantity = takerQuantity * price.Value;
-                    makerQuantity = Round(makerQuantity, rounding.Size);
-
+                    // Taker quantity is the asset amount for market buy orders
+                    takerQuantity = makerQuantity / price.Value;
+                    takerQuantity = RoundDown(takerQuantity, rounding.Size);
                 }
                 else
                 {
-                    takerQuantity = RoundDown(quantity, rounding.Size);
-                    makerQuantity = takerQuantity * price.Value;
+					// Taker quantity is the asset amount for limit buy orders
+					// and then used to calculate the maker quantity (USDC spend).
+					takerQuantity = RoundDown(quantity, rounding.Size);
+
+					// Maker quantity is the USDC spend for limit buy orders
+					makerQuantity = takerQuantity * price.Value;
 
                     if (GetDecimalPlaces(makerQuantity) > rounding.Amount)
                     {
@@ -273,7 +279,10 @@ namespace Polymarket.Net.Clients.ClobApi
             }
             else
             {
-                makerQuantity = RoundDown(quantity, rounding.Size);
+				// For sell orders, maker quantity is the asset amount and taker quantity is the USDC amount
+				// regardless of order type and then used to calculate the other quantity based on the price. 
+				// This is because for sell orders, the user is always giving the asset and receiving USDC.
+				makerQuantity = RoundDown(quantity, rounding.Size);
                 takerQuantity = makerQuantity * price.Value;
 
                 if (GetDecimalPlaces(takerQuantity) > rounding.Amount)

--- a/Polymarket.Net/Clients/ClobApi/PolymarketRestClientClobApiTrading.cs
+++ b/Polymarket.Net/Clients/ClobApi/PolymarketRestClientClobApiTrading.cs
@@ -248,17 +248,16 @@ namespace Polymarket.Net.Clients.ClobApi
                 {
 					// Maker quantity is USDC spend for market buy orders and
 					// then used to calculate the taker quantity (asset amount).
-					makerQuantity = quantity;
-                    if (GetDecimalPlaces(makerQuantity) > rounding.Amount)
-                    {
-                        makerQuantity = RoundUp(makerQuantity, rounding.Amount + 4);
-                        if (GetDecimalPlaces(makerQuantity) > rounding.Amount)
-                            makerQuantity = RoundDown(makerQuantity, rounding.Amount);
-                    }
+					makerQuantity = RoundDown(quantity, rounding.Size);
 
-                    // Taker quantity is the asset amount for market buy orders
-                    takerQuantity = makerQuantity / price.Value;
-                    takerQuantity = RoundDown(takerQuantity, rounding.Size);
+					// Taker quantity is the asset amount for market buy orders
+					takerQuantity = makerQuantity / price.Value;
+                    if (GetDecimalPlaces(takerQuantity) > rounding.Amount)
+                    {
+                        takerQuantity = RoundUp(takerQuantity, rounding.Amount + 4);
+                        if (GetDecimalPlaces(takerQuantity) > rounding.Amount)
+                            takerQuantity = RoundDown(takerQuantity, rounding.Amount);
+                    }
                 }
                 else
                 {

--- a/Polymarket.Net/Clients/ClobApi/PolymarketRestClientClobApiTrading.cs
+++ b/Polymarket.Net/Clients/ClobApi/PolymarketRestClientClobApiTrading.cs
@@ -55,8 +55,8 @@ namespace Polymarket.Net.Clients.ClobApi
             string tokenId,
             OrderSide side,
             OrderType orderType,
-            decimal quantity,
-            decimal? price = null,
+            decimal quantity, // <-- MARKET BUY: USDC amount, MARKET SELL: asset amount, LIMIT BUY: asset amount, LIMIT SELL: asset amount
+			decimal? price = null,
             TimeInForce? timeInForce = null,
             bool? postOnly = null,
             long? feeRateBps = null,

--- a/Polymarket.Net/Interfaces/Clients/ClobApi/IPolymarketRestClientClobApiTrading.cs
+++ b/Polymarket.Net/Interfaces/Clients/ClobApi/IPolymarketRestClientClobApiTrading.cs
@@ -68,8 +68,22 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// <param name="ct">Cancellation token</param>
         Task<WebCallResult<Dictionary<string, bool>>> GetOrdersRewardScoringAsync(IEnumerable<string> orderIds, CancellationToken ct = default);
 
+		/// <summary>
+		/// Place a new limit order. Quantity represents the asset/shares amount to sell/buy.
+		/// <para>
+		/// Docs:<br />
+		/// <a href="https://docs.polymarket.com/developers/CLOB/orders/create-order" /><br />
+		/// Endpoint:<br />
+		/// POST /order
+		/// </para>
+		/// </summary>
+		Task<WebCallResult<PolymarketOrderResult>> PlaceOrderAsync(
+            PolymarketOrderRequest request,
+            CancellationToken ct = default);
+
         /// <summary>
-        /// Place a new order
+        /// Place a new market order. For BUY orders, amount represents the USDC spend amount.
+        /// For SELL orders, amount represents the asset/shares amount.
         /// <para>
         /// Docs:<br />
         /// <a href="https://docs.polymarket.com/developers/CLOB/orders/create-order" /><br />
@@ -77,36 +91,28 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// POST /order
         /// </para>
         /// </summary>
-        /// <param name="tokenId">["<c>order.tokenId</c>"] Token id</param>
-        /// <param name="side">["<c>order.side</c>"] Side</param>
-        /// <param name="orderType">Type of order</param>
-        /// <param name="timeInForce">["<c>orderType</c>"] Time in force</param>
-        /// <param name="quantity">Quantity of shares</param>
-        /// <param name="price">Price, value between 0 and 1. For example 0.001 means 0.1c in the UI, 0.5 means 50c in UI</param>
-        /// <param name="postOnly">["<c>postOnly</c>"] Post only order</param>
-        /// <param name="feeRateBps">["<c>order.feeRateBps</c>"] Fee rate basis points as required by the operator</param>
-        /// <param name="takerAddress">["<c>order.taker</c>"] Taker/operator address</param>
-        /// <param name="clientOrderId">["<c>order.salt</c>"] Client order id</param>
-        /// <param name="expiration">["<c>order.expiration</c>"] Expiration time</param>
-        /// <param name="nonce">["<c>order.nonce</c>"] Nonce</param>
+        /// <param name="request">Market order request</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketOrderResult>> PlaceOrderAsync(
-            string tokenId,
-            OrderSide side,
-            OrderType orderType,
-            decimal quantity,
-            decimal? price = null,
-            TimeInForce? timeInForce = null,
-            bool? postOnly = null,
-            long? feeRateBps = null,
-            string? takerAddress = null,
-            long? clientOrderId = null,
-            DateTime? expiration = null,
-            long? nonce = null,
+        Task<WebCallResult<PolymarketOrderResult>> PlaceMarketOrderAsync(
+            PolymarketMarketOrderRequest request,
             CancellationToken ct = default);
 
+		/// <summary>
+		/// Place multiple limit orders in a single request. Quantity represents the asset/shares amount to sell/buy.
+		/// <para>
+		/// Docs:<br />
+		/// <a href="https://docs.polymarket.com/developers/CLOB/orders/create-order-batch" /><br />
+		/// Endpoint:<br />
+		/// POST /orders
+		/// </para>
+		/// </summary>
+		/// <param name="requests">Order requests</param>
+		/// <param name="ct">Cancellation token</param>
+		Task<WebCallResult<CallResult<PolymarketOrderResult>[]>> PlaceMultipleOrdersAsync(IEnumerable<PolymarketOrderRequest> requests, CancellationToken ct = default);
+
         /// <summary>
-        /// Place multiple orders in a single request
+        /// Place multiple market orders in a single request. For BUY orders, amount represents the USDC spend amount.
+        /// For SELL orders, amount represents the asset/shares amount.
         /// <para>
         /// Docs:<br />
         /// <a href="https://docs.polymarket.com/developers/CLOB/orders/create-order-batch" /><br />
@@ -114,9 +120,9 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// POST /orders
         /// </para>
         /// </summary>
-        /// <param name="requests">Order requests</param>
+        /// <param name="requests">Market order requests</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<CallResult<PolymarketOrderResult>[]>> PlaceMultipleOrdersAsync(IEnumerable<PolymarketOrderRequest> requests, CancellationToken ct = default);
+        Task<WebCallResult<CallResult<PolymarketOrderResult>[]>> PlaceMultipleMarketOrdersAsync(IEnumerable<PolymarketMarketOrderRequest> requests, CancellationToken ct = default);
 
         /// <summary>
         /// Cancel an order

--- a/Polymarket.Net/Objects/Models/PolymarketMarketOrderRequest.cs
+++ b/Polymarket.Net/Objects/Models/PolymarketMarketOrderRequest.cs
@@ -4,9 +4,10 @@ using System;
 namespace Polymarket.Net.Objects.Models
 {
     /// <summary>
-    /// Order request
+    /// Market order request. For market orders, the amount parameter represents
+    /// the USDC spend for BUY orders or the asset amount for SELL orders.
     /// </summary>
-    public record PolymarketOrderRequest
+    public record PolymarketMarketOrderRequest
     {
         /// <summary>
         /// Token id
@@ -16,24 +17,16 @@ namespace Polymarket.Net.Objects.Models
         /// Order side
         /// </summary>
         public OrderSide Side { get; set; }
-		/// <summary>
-		/// Quantity of asset/shares
-		/// </summary>
-		public decimal Quantity { get; set; }
-		/// <summary>
-		/// Price: Value between 0 and 1. For example 0.001 means 0.1c in the UI, 0.5 means 50c in UI
-		/// </summary>
-		public decimal? Price { get; set; }
+        /// <summary>
+        /// Amount: BUY = USDC spend amount, SELL = asset/shares amount
+        /// </summary>
+        public decimal Amount { get; set; }
         /// <summary>
         /// Time in force
         /// </summary>
         public TimeInForce? TimeInForce { get; set; }
         /// <summary>
-        /// Is post only
-        /// </summary>
-        public bool? PostOnly { get; set; }
-        /// <summary>
-        /// Fee rate BPS required by operator
+        /// Fee rate BPS
         /// </summary>
         public long? FeeRateBps { get; set; }
         /// <summary>
@@ -52,6 +45,5 @@ namespace Polymarket.Net.Objects.Models
         /// Nonce
         /// </summary>
         public long? Nonce { get; set; }
-
     }
 }

--- a/Polymarket.Net/Objects/Models/PolymarketOrderRequest.cs
+++ b/Polymarket.Net/Objects/Models/PolymarketOrderRequest.cs
@@ -24,10 +24,10 @@ namespace Polymarket.Net.Objects.Models
         /// Order type
         /// </summary>
         public OrderType OrderType { get; set; }
-        /// <summary>
-        /// Quantity
-        /// </summary>
-        public decimal Quantity { get; set; }
+		/// <summary>
+		/// Quantity: MARKET BUY: USDC amount, MARKET SELL: asset amount, LIMIT BUY: asset amount, LIMIT SELL: asset amount
+		/// </summary>
+		public decimal Quantity { get; set; }
         /// <summary>
         /// Price
         /// </summary>


### PR DESCRIPTION
This change distinguishes between MARKET and LIMIT order requests in order to align with standard pattern which is for MARKET BUY orders, the USCD amount should be specified, not the token/shares amount. The original methods method were expecting only shares amount (via quantity parameter/property), which causes an incorrect calculation/size of makerQuantity mentioned in Issue: https://github.com/JKorf/Polymarket.Net/issues/27

The concern of simply adding 2 new methods ( PlaceMarketOrderAsync() and PlaceMultipleMarketOrdersAsync() ) and not adjusting the existing methods, was that existing developers may not know the new methods are available because existing code will compile with no errors.  With the updated code, the developers will get a compilation errors now, requiring them to update their code and properly choose the correct method.  The existing methods can still be invoked with same parameters, but for MARKET orders, the new methods should be used. 

There is some code cleanup as well, such as taking the PolymarketOrderRequest and PolymarketMarketOrderRequest object as a parameter on the PlaceOrderAsync() and PlaceMarketOrderAsync() methods and remove the OrderType property on these objects, since they are not defined specifcally for LIMIT vs MARKET.