### PR TITLE
Add keyset pagination for events API

### DIFF
--- a/Polymarket.Net/Clients/GammaApi/PolymarketRestClientGammaApi.cs
+++ b/Polymarket.Net/Clients/GammaApi/PolymarketRestClientGammaApi.cs
@@ -248,6 +248,96 @@ namespace Polymarket.Net.Clients.GammaApi
         #region Get Events
 
         /// <inheritdoc />
+        public async Task<WebCallResult<PolymarketEventPage>> GetEventsKeysetPaginationAsync(
+            long[]? ids = null,
+            long[]? tagIds = null,
+            long[]? excludeTagIds = null,
+            string[]? slugs = null,
+            string? tagSlug = null,
+            bool? relatedTags = null,
+            bool? closed = null,
+            bool? live = null,
+            bool? featured = null,
+            bool? cyom = null,
+            string? titleSearch = null,
+            decimal? liquidityMin = null,
+            decimal? liquidityMax = null,
+            decimal? volumeMin = null,
+            decimal? volumeMax = null,
+            DateTime? startDateMin = null,
+            DateTime? startDateMax = null,
+            DateTime? endDateMin = null,
+            DateTime? endDateMax = null,
+            DateTime? startTimeMin = null,
+            DateTime? startTimeMax = null,
+            long[]? seriesIds = null,
+            long[]? gameIds = null,
+            DateTime? eventDate = null,
+            int? eventWeek = null,
+            bool? featuredOrder = null,
+            string? recurrence = null,
+            string[]? createdBy = null,
+            long? parentEventId = null,
+            bool? includeChildren = null,
+            string? partnerSlug = null,
+            bool? includeChat = null,
+            bool? includeTemplate = null,
+            bool? includeBestLines = null,
+            string? locale = null,
+            int? limit = null,
+            string? afterCursor = null,
+            IEnumerable<string>? orderBy = null,
+            bool? ascending = null,
+            CancellationToken ct = default)
+        {
+            var parameters = new ParameterCollection();
+            parameters.AddOptional("id", ids);
+            parameters.AddOptional("tag_id", tagIds);
+            parameters.AddOptional("exclude_tag_id", excludeTagIds);
+            parameters.AddOptional("slug", slugs);
+            parameters.AddOptional("tag_slug", tagSlug);
+            parameters.AddOptionalBoolString("related_tags", relatedTags);
+            parameters.AddOptionalBoolString("closed", closed);
+            parameters.AddOptionalBoolString("live", live);
+            parameters.AddOptionalBoolString("featured", featured);
+            parameters.AddOptionalBoolString("cyom", cyom);
+            parameters.AddOptional("title_search", titleSearch);
+            parameters.AddOptionalString("liquidity_min", liquidityMin);
+            parameters.AddOptionalString("liquidity_max", liquidityMax);
+            parameters.AddOptionalString("volume_min", volumeMin);
+            parameters.AddOptionalString("volume_max", volumeMax);
+            parameters.AddOptionalString("start_date_min", startDateMin);
+            parameters.AddOptionalString("start_date_max", startDateMax);
+            parameters.AddOptionalString("end_date_min", endDateMin);
+            parameters.AddOptionalString("end_date_max", endDateMax);
+            parameters.AddOptionalString("start_time_min", startTimeMin);
+            parameters.AddOptionalString("start_time_max", startTimeMax);
+            parameters.AddOptional("series_id", seriesIds);
+            parameters.AddOptional("game_id", gameIds);
+            parameters.AddOptionalString("event_date", eventDate);
+            parameters.AddOptional("event_week", eventWeek);
+            parameters.AddOptionalBoolString("featured_order", featuredOrder);
+            parameters.AddOptional("recurrence", recurrence);
+            parameters.AddOptional("created_by", createdBy);
+            parameters.AddOptional("parent_event_id", parentEventId);
+            parameters.AddOptionalBoolString("include_children", includeChildren);
+            parameters.AddOptional("partner_slug", partnerSlug);
+            parameters.AddOptionalBoolString("include_chat", includeChat);
+            parameters.AddOptionalBoolString("include_template", includeTemplate);
+            parameters.AddOptionalBoolString("include_best_lines", includeBestLines);
+            parameters.AddOptional("locale", locale);
+            parameters.AddOptional("after_cursor", afterCursor);
+            parameters.AddOptionalCommaSeparated("order", orderBy);
+            parameters.AddOptionalBoolString("ascending", ascending);
+            parameters.Add("limit", limit ?? 20);
+
+            var request = _definitions.GetOrCreate(HttpMethod.Get, $"events/keyset", PolymarketPlatform.RateLimiter.GammaApi, 1, false,
+                limitGuard: new SingleLimitGuard(500, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
+            return await SendAsync<PolymarketEventPage>(request, parameters, ct).ConfigureAwait(false);
+        }
+
+
+        /// <inheritdoc />
         public async Task<WebCallResult<PolymarketEvent[]>> GetEventsAsync(
             long[]? ids = null,
             long? tagId = null,

--- a/Polymarket.Net/Converters/PolymarketSourceGenerationContext.cs
+++ b/Polymarket.Net/Converters/PolymarketSourceGenerationContext.cs
@@ -24,6 +24,7 @@ namespace Polymarket.Net.Converters
     [JsonSerializable(typeof(PolymarketSeries[]))]
     [JsonSerializable(typeof(PolymarketGammaMarket))]
     [JsonSerializable(typeof(PolymarketGammaMarket[]))]
+    [JsonSerializable(typeof(PolymarketEventPage))]
     [JsonSerializable(typeof(PolymarketEvent[]))]
     [JsonSerializable(typeof(PolymarketRelatedTag[]))]
     [JsonSerializable(typeof(PolymarketTag))]

--- a/Polymarket.Net/Interfaces/Clients/GammaApi/IPolymarketRestClientGammaApi.cs
+++ b/Polymarket.Net/Interfaces/Clients/GammaApi/IPolymarketRestClientGammaApi.cs
@@ -188,6 +188,97 @@ namespace Polymarket.Net.Interfaces.Clients.GammaApi
         /// Get events
         /// <para>
         /// Docs:<br />
+        /// <a href="https://docs.polymarket.com/api-reference/events/list-events-keyset-pagination" /><br />
+        /// Endpoint:<br />
+        /// GET /events/keyset
+        /// </para>
+        /// </summary>
+        /// <param name="ids">["<c>id</c>"] Filter by ids</param>
+        /// <param name="tagIds">["<c>tag_id</c>"] Filter by tag ids</param>
+        /// <param name="excludeTagIds">["<c>exclude_tag_id</c>"] Filter by excluded tag ids</param>
+        /// <param name="slugs">["<c>slug</c>"] Filter by slugs</param>
+        /// <param name="tagSlug">["<c>tag_slug</c>"] Filter by tag slug</param>
+        /// <param name="relatedTags">["<c>related_tags</c>"] Filter by related tags</param>
+        /// <param name="closed">["<c>closed</c>"] Whether to return closed</param>
+        /// <param name="live">["<c>live</c>"] Whether to return live</param>
+        /// <param name="featured">["<c>featured</c>"] Whether to return featured</param>
+        /// <param name="cyom">["<c>cyom</c>"] Whether to return cyom</param>
+        /// <param name="titleSearch">["<c>title_search</c>"] Search by title</param>
+        /// <param name="liquidityMin">["<c>liquidity_min</c>"] Filter by min liquidity</param>
+        /// <param name="liquidityMax">["<c>liquidity_max</c>"] Filter by max liquidity</param>
+        /// <param name="volumeMin">["<c>volume_min</c>"] Filter by min volume</param>
+        /// <param name="volumeMax">["<c>volume_max</c>"] Filter by max volume</param>
+        /// <param name="startDateMin">["<c>start_date_min</c>"] Filter start date by min value</param>
+        /// <param name="startDateMax">["<c>start_date_max</c>"] Filter start date by max value</param>
+        /// <param name="endDateMin">["<c>end_date_min</c>"] Filter end date by min value</param>
+        /// <param name="endDateMax">["<c>end_date_max</c>"] Filter end date by max value</param>
+        /// <param name="startTimeMin">["<c>start_time_min</c>"] Filter start time by min value</param>
+        /// <param name="startTimeMax">["<c>start_time_max</c>"] Filter start time by max value</param>
+        /// <param name="seriesIds">["<c>series_id</c>"] Filter by series ids</param>
+        /// <param name="gameIds">["<c>game_id</c>"] Filter by game ids</param>
+        /// <param name="eventDate">["<c>event_date</c>"] Filter by event date</param>
+        /// <param name="eventWeek">["<c>event_week</c>"] Filter by event week</param>
+        /// <param name="featuredOrder">["<c>featured_order</c>"] Whether to return featured order</param>
+        /// <param name="recurrence">["<c>recurrence</c>"] Whether to return recurrence</param>
+        /// <param name="createdBy">["<c>created_by</c>"] Filter by created by</param>
+        /// <param name="parentEventId">["<c>parent_event_id</c>"] Filter by parent event id</param>
+        /// <param name="includeChildren">["<c>include_children</c>"] Whether to include children</param>
+        /// <param name="partnerSlug">["<c>partner_slug</c>"] Partner slug</param>
+        /// <param name="includeChat">["<c>include_chat</c>"] Whether to include chat</param>
+        /// <param name="includeTemplate">["<c>include_template</c>"] Whether to include template</param>
+        /// <param name="includeBestLines">["<c>include_best_lines</c>"] Whether to include best lines</param>
+        /// <param name="locale">["<c>locale</c>"] Locale</param>
+        /// <param name="limit">["<c>limit</c>"] Max number of results</param>
+        /// <param name="afterCursor">["<c>after_cursor</c>"] Cursor from previous response</param>
+        /// <param name="orderBy">["<c>order</c>"] Order by fields</param>
+        /// <param name="ascending">["<c>ascending</c>"] Ascending order</param>
+        /// <param name="ct">Cancellation token</param>
+        Task<WebCallResult<PolymarketEventPage>> GetEventsKeysetPaginationAsync(
+            long[]? ids = null,
+            long[]? tagIds = null,
+            long[]? excludeTagIds = null,
+            string[]? slugs = null,
+            string? tagSlug = null,
+            bool? relatedTags = null,
+            bool? closed = null,
+            bool? live = null,
+            bool? featured = null,
+            bool? cyom = null,
+            string? titleSearch = null,
+            decimal? liquidityMin = null,
+            decimal? liquidityMax = null,
+            decimal? volumeMin = null,
+            decimal? volumeMax = null,
+            DateTime? startDateMin = null,
+            DateTime? startDateMax = null,
+            DateTime? endDateMin = null,
+            DateTime? endDateMax = null,
+            DateTime? startTimeMin = null,
+            DateTime? startTimeMax = null,
+            long[]? seriesIds = null,
+            long[]? gameIds = null,
+            DateTime? eventDate = null,
+            int? eventWeek = null,
+            bool? featuredOrder = null,
+            string? recurrence = null,
+            string[]? createdBy = null,
+            long? parentEventId = null,
+            bool? includeChildren = null,
+            string? partnerSlug = null,
+            bool? includeChat = null,
+            bool? includeTemplate = null,
+            bool? includeBestLines = null,
+            string? locale = null,
+            int? limit = null,
+            string? afterCursor = null,
+            IEnumerable<string>? orderBy = null,
+            bool? ascending = null,
+            CancellationToken ct = default);
+
+        /// <summary>
+        /// Get events
+        /// <para>
+        /// Docs:<br />
         /// <a href="https://docs.polymarket.com/api-reference/events/list-events" /><br />
         /// Endpoint:<br />
         /// GET /events

--- a/Polymarket.Net/Objects/Models/PolymarketEventPage.cs
+++ b/Polymarket.Net/Objects/Models/PolymarketEventPage.cs
@@ -1,0 +1,22 @@
+using System.Text.Json.Serialization;
+
+namespace Polymarket.Net.Objects.Models
+{
+    /// <summary>
+    /// Events page
+    /// </summary>
+    public record PolymarketEventPage
+    {
+        /// <summary>
+        /// ["<c>events</c>"] Events
+        /// </summary>
+        [JsonPropertyName("events")]
+        public PolymarketEvent[] Events { get; set; } = [];
+
+        /// <summary>
+        /// ["<c>next_cursor</c>"] Pagination cursor
+        /// </summary>
+        [JsonPropertyName("next_cursor")]
+        public string? NextPageCursor { get; set; }
+    }
+}


### PR DESCRIPTION
Implemented GetEventsKeysetPaginationAsync for /events/keyset with full filtering and pagination support. Added PolymarketEventPage model and registered it for source generation. Updated interface and documentation accordingly.

Described in documentation
[Polymarket Docs](https://docs.polymarket.com/api-reference/events/list-events-keyset-pagination)

Sample usage:
```csharp
var client = new PolymarketRestClient();
var btcUpDown5mSeries = 10684;
var events = new List<PolymarketEvent>();
PolymarketEventPage? page = null;
do
{
    var result = await client.GammaApi.GetEventsKeysetPaginationAsync(
    limit: 100,
    ascending: true,
    closed: false,
    seriesIds: [btcUpDown5mSeries],
    afterCursor: page?.NextPageCursor
    );

    if (result.Success)
    {
        page = result.Data;
        events.AddRange(page.Events);
    }
}
while(page?.NextPageCursor is not null);

Console.WriteLine($"count of all active btc-updown-5m events: {events.Count()}");
```