### PR TITLE
CryptoExchange.Net V12

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ var restClient = new PolymarketRestClient(options =>
 
 ## Core Pattern: Result Handling
 
-Every REST method returns `WebCallResult<T>` or `WebCallResult`. WebSocket subscriptions return `CallResult<UpdateSubscription>`. Always check `.Success` before accessing `.Data`.
+Every REST method returns `HttpResult<T>` or `HttpResult`. WebSocket subscriptions return `WebSocketResult<UpdateSubscription>`. Always check `.Success` before accessing `.Data`.
 
 ```csharp
 var markets = await restClient.ClobApi.ExchangeData.GetMarketsAsync();
@@ -197,7 +197,7 @@ For a maintained local CLOB order book use `PolymarketClobSymbolOrderBook` or `I
 - Do not instantiate clients per request in production code; reuse clients or use DI.
 - Do not place/cancel orders with L1-only credentials; create/derive L2 credentials first or configure both levels.
 - Do not document `.SharedClient`; it is not exposed by the current Polymarket.Net client interfaces.
-- Do not confuse `PolymarketOrderResult.Success` with `WebCallResult.Success`; check both if you need to know whether the API call succeeded and whether the order itself was accepted.
+- Do not confuse `PolymarketOrderResult.Success` with `HttpResult.Success`; check both if you need to know whether the API call succeeded and whether the order itself was accepted.
 
 ## Environments
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ var restClient = new PolymarketRestClient(options =>
 
 ## Core Pattern: Result Handling
 
-Every REST method returns `HttpResult<T>` or `HttpResult`. WebSocket subscriptions return `WebSocketResult<UpdateSubscription>`. Always check `.Success` before accessing `.Data`.
+Every REST method returns `HttpResult<T>` or `HttpResult`. WebSocket subscription methods return `WebSocketResult<UpdateSubscription>`. Always check `.Success` before accessing `.Data`.
 
 ```csharp
 var markets = await restClient.ClobApi.ExchangeData.GetMarketsAsync();

--- a/Examples/ai-friendly/02-authentication-and-trading.cs
+++ b/Examples/ai-friendly/02-authentication-and-trading.cs
@@ -50,7 +50,7 @@ if (!order.Success)
     return;
 }
 
-// A successful WebCallResult means the request completed. The order payload also
+// A successful HttpResult means the request completed. The order payload also
 // has an acceptance flag and error message from Polymarket.
 if (!order.Data.Success)
 {

--- a/Examples/ai-friendly/03-websocket.cs
+++ b/Examples/ai-friendly/03-websocket.cs
@@ -7,6 +7,7 @@ var socketClient = new PolymarketSocketClient();
 var tokenId = "TOKEN_ID";
 
 // Public token stream. All handlers are optional; pass only the events you need.
+// Socket subscriptions return WebSocketResult<UpdateSubscription>.
 var tokenSubscription = await socketClient.ClobApi.SubscribeToTokenUpdatesAsync(
     new[] { tokenId },
     onPriceChangeUpdate: update => Console.WriteLine($"Price update: {update.Data}"),

--- a/Examples/ai-friendly/05-error-handling.cs
+++ b/Examples/ai-friendly/05-error-handling.cs
@@ -6,6 +6,7 @@ using Polymarket.Net.Objects.Models;
 var client = new PolymarketRestClient();
 var tokenId = "TOKEN_ID";
 
+// REST methods return HttpResult<T> or HttpResult.
 var book = await WithRetry(() => client.ClobApi.ExchangeData.GetOrderBookAsync(tokenId));
 if (!book.Success)
 {
@@ -16,6 +17,7 @@ if (!book.Success)
 Console.WriteLine($"Loaded order book with {book.Data.Bids.Length} bids.");
 
 // Normal API failures are returned in HttpResult.Error, not thrown.
+// Socket subscriptions use WebSocketResult<UpdateSubscription> with the same Success/Error pattern.
 var price = await client.ClobApi.ExchangeData.GetPriceAsync(tokenId, OrderSide.Buy);
 if (!price.Success)
 {

--- a/Examples/ai-friendly/05-error-handling.cs
+++ b/Examples/ai-friendly/05-error-handling.cs
@@ -15,7 +15,7 @@ if (!book.Success)
 
 Console.WriteLine($"Loaded order book with {book.Data.Bids.Length} bids.");
 
-// Normal API failures are returned in WebCallResult.Error, not thrown.
+// Normal API failures are returned in HttpResult.Error, not thrown.
 var price = await client.ClobApi.ExchangeData.GetPriceAsync(tokenId, OrderSide.Buy);
 if (!price.Success)
 {
@@ -26,9 +26,9 @@ if (!price.Success)
 Console.WriteLine("Price request succeeded.");
 
 // Trading responses have two layers:
-// 1. WebCallResult.Success: request/transport/API call succeeded.
+// 1. HttpResult.Success: request/transport/API call succeeded.
 // 2. PolymarketOrderResult.Success: Polymarket accepted the order.
-static bool IsAcceptedOrder(WebCallResult<PolymarketOrderResult> order)
+static bool IsAcceptedOrder(HttpResult<PolymarketOrderResult> order)
 {
     if (!order.Success)
     {
@@ -45,9 +45,9 @@ static bool IsAcceptedOrder(WebCallResult<PolymarketOrderResult> order)
     return true;
 }
 
-static async Task<WebCallResult<T>> WithRetry<T>(Func<Task<WebCallResult<T>>> call, int maxAttempts = 3)
+static async Task<HttpResult<T>> WithRetry<T>(Func<Task<HttpResult<T>>> call, int maxAttempts = 3)
 {
-    WebCallResult<T> last = default!;
+    HttpResult<T> last = default!;
 
     for (var attempt = 1; attempt <= maxAttempts; attempt++)
     {
@@ -67,5 +67,5 @@ static async Task<WebCallResult<T>> WithRetry<T>(Func<Task<WebCallResult<T>>> ca
 }
 
 // Keep this helper reachable for the compiler while avoiding a live order request.
-Func<WebCallResult<PolymarketOrderResult>, bool> orderAccepted = IsAcceptedOrder;
+Func<HttpResult<PolymarketOrderResult>, bool> orderAccepted = IsAcceptedOrder;
 Console.WriteLine(orderAccepted.Method.Name);

--- a/Examples/ai-friendly/README.md
+++ b/Examples/ai-friendly/README.md
@@ -15,7 +15,7 @@ These examples are optimized for AI coding assistants and quick onboarding. Each
 | `02-authentication-and-trading.cs` | L1/L2 credentials, deriving L2 credentials, allowance checks, limit order placement, open orders and cancellation |
 | `03-websocket.cs` | Platform, token, user and sports subscriptions with success checks and teardown |
 | `04-di-and-orderbook.cs` | Dependency injection, injected clients, local order book factory and per-user client provider |
-| `05-error-handling.cs` | `WebCallResult` patterns, retry logic, order acceptance checks and common Polymarket mistakes |
+| `05-error-handling.cs` | `HttpResult` patterns, retry logic, order acceptance checks and common Polymarket mistakes |
 
 ## Running
 

--- a/Polymarket.Net.UnitTests/PolymarketRestClientTests.cs
+++ b/Polymarket.Net.UnitTests/PolymarketRestClientTests.cs
@@ -23,7 +23,7 @@ namespace Polymarket.Net.UnitTests
 
             var authProvider = new PolymarketAuthenticationProvider(new PolymarketCredentials().WithL1(Enums.SignType.EOA, privateKey, address));
 
-            var parameters = new ParameterCollection
+            var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings)
             {
                 { "salt", "479249096354" },
                 { "maker", address },
@@ -52,7 +52,7 @@ namespace Polymarket.Net.UnitTests
 
             var authProvider = new PolymarketAuthenticationProvider(new PolymarketCredentials().WithL1(Enums.SignType.EOA, privateKey, address));
 
-            var parameters = new ParameterCollection
+            var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings)
             {
                 { "salt", "1515433236867" },
                 { "maker", address },

--- a/Polymarket.Net.UnitTests/RestRequestTests.cs
+++ b/Polymarket.Net.UnitTests/RestRequestTests.cs
@@ -50,7 +50,7 @@ namespace Polymarket.Net.UnitTests
             await tester.ValidateAsync(client => client.ClobApi.Trading.GetUserTradesAsync("123"), "GetUserTrades");
         }
 
-        private bool IsAuthenticated(WebCallResult result)
+        private bool IsAuthenticated(IHttpResult result)
         {
             return result.RequestHeaders?.Contains("POLY_SIGNATURE") == true;
         }

--- a/Polymarket.Net.UnitTests/SocketSubscriptionTests.cs
+++ b/Polymarket.Net.UnitTests/SocketSubscriptionTests.cs
@@ -38,7 +38,7 @@ namespace Polymarket.Net.UnitTests
                 OutputOriginalData = true
             }), logger);
 
-            var tester = new SocketSubscriptionValidator<PolymarketSocketClient>(client, "Subscriptions/Clob", "wss://ws-subscriptions-clob.polymarket.com", "data");
+            var tester = new SocketSubscriptionValidator<PolymarketSocketClient>(client, "Subscriptions/Clob", "wss://ws-subscriptions-clob.polymarket.com/ws/market", "data");
             await tester.ValidateConcurrentAsync<PolymarketPriceChangeUpdate>(
                 (client, handler) => client.ClobApi.SubscribeToTokenUpdatesAsync(["0x123"], handler),
                 (client, handler) => client.ClobApi.SubscribeToTokenUpdatesAsync(["0x456"], handler),

--- a/Polymarket.Net/Clients/ClobApi/PolymarketRestClientClobApi.cs
+++ b/Polymarket.Net/Clients/ClobApi/PolymarketRestClientClobApi.cs
@@ -36,13 +36,11 @@ namespace Polymarket.Net.Clients.ClobApi
         public IPolymarketRestClientClobApiExchangeData ExchangeData { get; }
         /// <inheritdoc />
         public IPolymarketRestClientClobApiTrading Trading { get; }
-        /// <inheritdoc />
-        public string ExchangeName => "Polymarket";
         #endregion
 
         #region constructor/destructor
         internal PolymarketRestClientClobApi(ILogger logger, HttpClient? httpClient, PolymarketRestOptions options)
-            : base(logger, httpClient, options.Environment.ClobRestClientAddress, options, options.ClobOptions)
+            : base(logger, PolymarketPlatform.Metadata.Id, httpClient, options.Environment.ClobRestClientAddress, options, options.ClobOptions)
         {
             Account = new PolymarketRestClientClobApiAccount(this);
             ExchangeData = new PolymarketRestClientClobApiExchangeData(logger, this);
@@ -50,8 +48,6 @@ namespace Polymarket.Net.Clients.ClobApi
 
             RequestBodyEmptyContent = "";
             ParameterPositions[HttpMethod.Delete] = HttpMethodParameterPosition.InBody;
-
-            OrderParameters = false;
         }
         #endregion
 
@@ -63,32 +59,20 @@ namespace Polymarket.Net.Clients.ClobApi
         protected override PolymarketAuthenticationProvider CreateAuthenticationProvider(PolymarketCredentials credentials)
             => new PolymarketAuthenticationProvider(credentials);
 
-        internal Task<WebCallResult> SendAsync(RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null)
-            => SendToAddressAsync(BaseAddress, definition, parameters, cancellationToken, weight);
-
-        internal async Task<WebCallResult> SendToAddressAsync(string baseAddress, RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null)
+        internal async Task<HttpResult> SendAsync(RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null)
         {
-            var result = await base.SendAsync(baseAddress, definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
-
-            // Optional response checking
-
+            var result = await base.SendAsync<Unit>(definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
             return result;
         }
 
-        internal Task<WebCallResult<T>> SendAsync<T>(RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null)
-            => SendToAddressAsync<T>(BaseAddress, definition, parameters, cancellationToken, weight);
-
-        internal async Task<WebCallResult<T>> SendToAddressAsync<T>(string baseAddress, RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null)
+        internal async Task<HttpResult<T>> SendAsync<T>(RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null)
         {
-            var result = await base.SendAsync<T>(baseAddress, definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
-
-            // Optional response checking
-
+            var result = await base.SendAsync<T>(definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
             return result;
         }
 
         /// <inheritdoc />
-        protected override Task<WebCallResult<DateTime>> GetServerTimestampAsync()
+        protected override Task<HttpResult<DateTime>> GetServerTimestampAsync()
             => ExchangeData.GetServerTimeAsync();
 
         /// <inheritdoc />

--- a/Polymarket.Net/Clients/ClobApi/PolymarketRestClientClobApi.cs
+++ b/Polymarket.Net/Clients/ClobApi/PolymarketRestClientClobApi.cs
@@ -39,12 +39,12 @@ namespace Polymarket.Net.Clients.ClobApi
         #endregion
 
         #region constructor/destructor
-        internal PolymarketRestClientClobApi(ILogger logger, HttpClient? httpClient, PolymarketRestOptions options)
-            : base(logger, PolymarketPlatform.Metadata.Id, httpClient, options.Environment.ClobRestClientAddress, options, options.ClobOptions)
+        internal PolymarketRestClientClobApi(ILoggerFactory? loggerFactory, HttpClient? httpClient, PolymarketRestOptions options)
+            : base(loggerFactory, PolymarketPlatform.Metadata.Id, httpClient, options.Environment.ClobRestClientAddress, options, options.ClobOptions)
         {
             Account = new PolymarketRestClientClobApiAccount(this);
-            ExchangeData = new PolymarketRestClientClobApiExchangeData(logger, this);
-            Trading = new PolymarketRestClientClobApiTrading(logger, this);
+            ExchangeData = new PolymarketRestClientClobApiExchangeData(_logger, this);
+            Trading = new PolymarketRestClientClobApiTrading(_logger, this);
 
             RequestBodyEmptyContent = "";
             ParameterPositions[HttpMethod.Delete] = HttpMethodParameterPosition.InBody;

--- a/Polymarket.Net/Clients/ClobApi/PolymarketRestClientClobApiAccount.cs
+++ b/Polymarket.Net/Clients/ClobApi/PolymarketRestClientClobApiAccount.cs
@@ -22,117 +22,117 @@ namespace Polymarket.Net.Clients.ClobApi
             _baseClient = baseClient;
         }
 
-        public async Task<WebCallResult<PolymarketCreds>> CreateApiCredentialsAsync(long? nonce = null, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketCreds>> CreateApiCredentialsAsync(long? nonce = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("nonce", nonce);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "auth/api-key", PolymarketPlatform.RateLimiter.ClobApi, 1, true);
+            var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
+            parameters.Add("nonce", nonce);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "auth/api-key", PolymarketPlatform.RateLimiter.ClobApi, 1, true);
             var result = await _baseClient.SendAsync<PolymarketCreds>(request, parameters, ct).ConfigureAwait(false);
             return result;
         }
 
-        public async Task<WebCallResult<PolymarketCreds>> GetApiCredentialsAsync(long? nonce = null, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketCreds>> GetApiCredentialsAsync(long? nonce = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("nonce", nonce);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "auth/derive-api-key", PolymarketPlatform.RateLimiter.ClobApi, 1, true);
+            var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
+            parameters.Add("nonce", nonce);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "auth/derive-api-key", PolymarketPlatform.RateLimiter.ClobApi, 1, true);
             var result = await _baseClient.SendAsync<PolymarketCreds>(request, parameters, ct).ConfigureAwait(false);
             return result;
         }
 
-        public async Task<WebCallResult<PolymarketCreds>> GetOrCreateApiCredentialsAsync(long? nonce = null, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketCreds>> GetOrCreateApiCredentialsAsync(long? nonce = null, CancellationToken ct = default)
         {
             var getResult = await GetApiCredentialsAsync(nonce, ct).ConfigureAwait(false);
-            if (getResult)
+            if (getResult.Success)
                 return getResult;
 
             return await CreateApiCredentialsAsync(nonce, ct).ConfigureAwait(false);
         }
 
-        public async Task<WebCallResult<PolymarketApiKeys>> GetApiKeysAsync(CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketApiKeys>> GetApiKeysAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "auth/api-keys", PolymarketPlatform.RateLimiter.ClobApi, 1, true);
+            var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "auth/api-keys", PolymarketPlatform.RateLimiter.ClobApi, 1, true);
             var result = await _baseClient.SendAsync<PolymarketApiKeys>(request, parameters, ct).ConfigureAwait(false);
             return result;
         }
 
-        public async Task<WebCallResult<PolymarketClosedOnlyMode>> GetClosedOnlyModeAsync(CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketClosedOnlyMode>> GetClosedOnlyModeAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "auth/ban-status/closed-only", PolymarketPlatform.RateLimiter.ClobApi, 1, true);
+            var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "auth/ban-status/closed-only", PolymarketPlatform.RateLimiter.ClobApi, 1, true);
             var result = await _baseClient.SendAsync<PolymarketClosedOnlyMode>(request, parameters, ct).ConfigureAwait(false);
             return result;
         }
 
-        public async Task<WebCallResult> DeleteApiKeyAsync(CancellationToken ct = default)
+        public async Task<HttpResult> DeleteApiKeyAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            var request = _definitions.GetOrCreate(HttpMethod.Delete, "auth/api-key", PolymarketPlatform.RateLimiter.ClobApi, 1, true);
+            var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
+            var request = _definitions.GetOrCreate(HttpMethod.Delete, _baseClient.BaseAddress, "auth/api-key", PolymarketPlatform.RateLimiter.ClobApi, 1, true);
             var result = await _baseClient.SendAsync(request, parameters, ct).ConfigureAwait(false);
             return result;
         }
 
         // TODO: read-only API keys
 
-        public async Task<WebCallResult<PolymarketNotification[]>> GetNotificationsAsync(CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketNotification[]>> GetNotificationsAsync(CancellationToken ct = default)
         {
             if (_baseClient.AuthenticationProvider == null)
-                return new WebCallResult<PolymarketNotification[]>(new NoApiCredentialsError());
+                return HttpResult.Fail<PolymarketNotification[]>(_baseClient.Exchange, new NoApiCredentialsError());
 
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
             parameters.Add("signature_type", (int)_baseClient.AuthenticationProvider.ApiCredentials.L1.SignType);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "notifications", PolymarketPlatform.RateLimiter.ClobApi, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "notifications", PolymarketPlatform.RateLimiter.ClobApi, 1, true,
                 limitGuard: new SingleLimitGuard(900, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<PolymarketNotification[]>(request, parameters, ct).ConfigureAwait(false);
             return result;
         }
 
-        public async Task<WebCallResult<PolymarketNotification[]>> DropNotificationsAsync(IEnumerable<string> ids, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketNotification[]>> DropNotificationsAsync(IEnumerable<string> ids, CancellationToken ct = default)
         {
             if (_baseClient.AuthenticationProvider == null)
-                return new WebCallResult<PolymarketNotification[]>(new NoApiCredentialsError());
+                return HttpResult.Fail<PolymarketNotification[]>(_baseClient.Exchange, new NoApiCredentialsError());
 
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
             parameters.Add("signature_type", (int)_baseClient.AuthenticationProvider.ApiCredentials.L1.SignType);
             parameters.Add("ids", string.Join(",", ids));
-            var request = _definitions.GetOrCreate(HttpMethod.Delete, "notifications", PolymarketPlatform.RateLimiter.ClobApi, 1, true, parameterPosition: HttpMethodParameterPosition.InUri,
+            var request = _definitions.GetOrCreate(HttpMethod.Delete, _baseClient.BaseAddress, "notifications", PolymarketPlatform.RateLimiter.ClobApi, 1, true, parameterPosition: HttpMethodParameterPosition.InUri,
                 limitGuard: new SingleLimitGuard(125, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<PolymarketNotification[]>(request, parameters, ct).ConfigureAwait(false);
             return result;
         }
 
-        public async Task<WebCallResult<PolymarketBalanceAllowance>> GetBalanceAllowanceAsync(AssetType assetType, string? tokenId = null, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketBalanceAllowance>> GetBalanceAllowanceAsync(AssetType assetType, string? tokenId = null, CancellationToken ct = default)
         {
             if (_baseClient.AuthenticationProvider == null)
-                return new WebCallResult<PolymarketBalanceAllowance>(new NoApiCredentialsError());
+                return HttpResult.Fail<PolymarketBalanceAllowance>(_baseClient.Exchange, new NoApiCredentialsError());
 
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
             parameters.Add("signature_type", (int)_baseClient.AuthenticationProvider.ApiCredentials.L1.SignType);
-            parameters.AddEnum("asset_type", assetType);
-            parameters.AddOptional("token_id", tokenId);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "balance-allowance", PolymarketPlatform.RateLimiter.ClobApi, 1, true,
+            parameters.Add("asset_type", assetType);
+            parameters.Add("token_id", tokenId);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "balance-allowance", PolymarketPlatform.RateLimiter.ClobApi, 1, true,
                 limitGuard: new SingleLimitGuard(200, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<PolymarketBalanceAllowance>(request, parameters, ct).ConfigureAwait(false);
             return result;
         }
 
-        public async Task<WebCallResult> UpdateBalanceAllowanceAsync(AssetType assetType, string? tokenId = null, CancellationToken ct = default)
+        public async Task<HttpResult> UpdateBalanceAllowanceAsync(AssetType assetType, string? tokenId = null, CancellationToken ct = default)
         {
             if (_baseClient.AuthenticationProvider == null)
-                return new WebCallResult(new NoApiCredentialsError());
+                return HttpResult.Fail(_baseClient.Exchange, new NoApiCredentialsError());
 
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
             parameters.Add("signature_type", (int)_baseClient.AuthenticationProvider.ApiCredentials.L1.SignType);
-            parameters.AddEnum("asset_type", assetType);
-            parameters.AddOptional("token_id", tokenId);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "balance-allowance/update", PolymarketPlatform.RateLimiter.ClobApi, 1, true,
+            parameters.Add("asset_type", assetType);
+            parameters.Add("token_id", tokenId);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "balance-allowance/update", PolymarketPlatform.RateLimiter.ClobApi, 1, true,
                 limitGuard: new SingleLimitGuard(50, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync(request, parameters, ct).ConfigureAwait(false);
             return result;
         }
 
-        public async Task<WebCallResult<PolymarketPage<PolymarketBuilderTrade>>> GetBuilderTradesAsync(
+        public async Task<HttpResult<PolymarketPage<PolymarketBuilderTrade>>> GetBuilderTradesAsync(
             string builderCode,
             string? tradeId = null,
             string? marketId = null,
@@ -142,15 +142,15 @@ namespace Polymarket.Net.Clients.ClobApi
             string? cursor = null, 
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
             parameters.Add("builder_code", builderCode);
-            parameters.AddOptional("id", tradeId);
-            parameters.AddOptional("market", marketId);
-            parameters.AddOptional("asset_id", tokenId);
-            parameters.AddOptionalMillisecondsString("after", startTime);
-            parameters.AddOptionalMillisecondsString("before", endTime);
-            parameters.AddOptional("next_cursor", cursor);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "builder/trades", PolymarketPlatform.RateLimiter.ClobApi, 1, true);
+            parameters.Add("id", tradeId);
+            parameters.Add("market", marketId);
+            parameters.Add("asset_id", tokenId);
+            parameters.Add("after", startTime);
+            parameters.Add("before", endTime);
+            parameters.Add("next_cursor", cursor);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "builder/trades", PolymarketPlatform.RateLimiter.ClobApi, 1, true);
             var result = await _baseClient.SendAsync<PolymarketPage<PolymarketBuilderTrade>>(request, parameters, ct).ConfigureAwait(false);
             return result;
         }

--- a/Polymarket.Net/Clients/ClobApi/PolymarketRestClientClobApiExchangeData.cs
+++ b/Polymarket.Net/Clients/ClobApi/PolymarketRestClientClobApiExchangeData.cs
@@ -29,11 +29,14 @@ namespace Polymarket.Net.Clients.ClobApi
         #region Get Server Time
 
         /// <inheritdoc />
-        public async Task<WebCallResult<DateTime>> GetServerTimeAsync(CancellationToken ct = default)
+        public async Task<HttpResult<DateTime>> GetServerTimeAsync(CancellationToken ct = default)
         {
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "time", PolymarketPlatform.RateLimiter.ClobApi, 1, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "time", PolymarketPlatform.RateLimiter.ClobApi, 1, false);
             var result = await _baseClient.SendAsync<long>(request, null, ct).ConfigureAwait(false);
-            return result.As(result.Success ? DateTimeConverter.ConvertFromSeconds(result.Data) : default);
+            if (!result.Success)
+                return HttpResult.Fail<DateTime>(result);
+
+            return HttpResult.Ok(result, DateTimeConverter.ConvertFromSeconds(result.Data)!);
         }
 
         #endregion
@@ -41,10 +44,10 @@ namespace Polymarket.Net.Clients.ClobApi
         #region Get Geographic Restrictions
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketGeoRestriction>> GetGeographicRestrictionsAsync(CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketGeoRestriction>> GetGeographicRestrictionsAsync(CancellationToken ct = default)
         {
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "api/geoblock", PolymarketPlatform.RateLimiter.ClobApi, 1, false);
-            return await _baseClient.SendToAddressAsync<PolymarketGeoRestriction>("https://polymarket.com", request, null, ct).ConfigureAwait(false);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, "https://polymarket.com", "api/geoblock", PolymarketPlatform.RateLimiter.ClobApi, 1, false);
+            return await _baseClient.SendAsync<PolymarketGeoRestriction>(request, null, ct).ConfigureAwait(false);
         }
 
         #endregion
@@ -52,11 +55,11 @@ namespace Polymarket.Net.Clients.ClobApi
         #region Get Sampling Simplified Markets
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketPage<PolymarketMarket>>> GetSamplingSimplifiedMarketsAsync(string? cursor = null, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketPage<PolymarketMarket>>> GetSamplingSimplifiedMarketsAsync(string? cursor = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("next_cursor", cursor);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "sampling-simplified-markets", PolymarketPlatform.RateLimiter.ClobApi, 1, false);
+            var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
+            parameters.Add("next_cursor", cursor);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "sampling-simplified-markets", PolymarketPlatform.RateLimiter.ClobApi, 1, false);
             return await _baseClient.SendAsync<PolymarketPage<PolymarketMarket>>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -65,11 +68,11 @@ namespace Polymarket.Net.Clients.ClobApi
         #region Get Sampling Markets
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketPage<PolymarketMarketDetails>>> GetSamplingMarketsAsync(string? cursor = null, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketPage<PolymarketMarketDetails>>> GetSamplingMarketsAsync(string? cursor = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("next_cursor", cursor);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "sampling-markets", PolymarketPlatform.RateLimiter.ClobApi, 1, false);
+            var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
+            parameters.Add("next_cursor", cursor);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "sampling-markets", PolymarketPlatform.RateLimiter.ClobApi, 1, false);
             return await _baseClient.SendAsync<PolymarketPage<PolymarketMarketDetails>>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -78,11 +81,11 @@ namespace Polymarket.Net.Clients.ClobApi
         #region Get Simplified Markets
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketPage<PolymarketMarket>>> GetSimplifiedMarketsAsync(string? cursor = null, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketPage<PolymarketMarket>>> GetSimplifiedMarketsAsync(string? cursor = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("next_cursor", cursor);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "simplified-markets", PolymarketPlatform.RateLimiter.ClobApi, 1, false);
+            var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
+            parameters.Add("next_cursor", cursor);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "simplified-markets", PolymarketPlatform.RateLimiter.ClobApi, 1, false);
             return await _baseClient.SendAsync<PolymarketPage<PolymarketMarket>>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -91,11 +94,11 @@ namespace Polymarket.Net.Clients.ClobApi
         #region Get Markets
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketPage<PolymarketMarketDetails>>> GetMarketsAsync(string? cursor = null, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketPage<PolymarketMarketDetails>>> GetMarketsAsync(string? cursor = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("next_cursor", cursor);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "markets", PolymarketPlatform.RateLimiter.ClobApi, 1, false);
+            var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
+            parameters.Add("next_cursor", cursor);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "markets", PolymarketPlatform.RateLimiter.ClobApi, 1, false);
             return await _baseClient.SendAsync<PolymarketPage<PolymarketMarketDetails>>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -104,9 +107,9 @@ namespace Polymarket.Net.Clients.ClobApi
         #region Get Market
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketMarketDetails>> GetMarketAsync(string marketId, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketMarketDetails>> GetMarketAsync(string marketId, CancellationToken ct = default)
         {
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "markets/" + marketId, PolymarketPlatform.RateLimiter.ClobApi, 1, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "markets/" + marketId, PolymarketPlatform.RateLimiter.ClobApi, 1, false);
             return await _baseClient.SendAsync<PolymarketMarketDetails>(request, null, ct).ConfigureAwait(false);
         }
 
@@ -115,12 +118,12 @@ namespace Polymarket.Net.Clients.ClobApi
         #region Get Price
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketPrice>> GetPriceAsync(string tokenId, OrderSide side, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketPrice>> GetPriceAsync(string tokenId, OrderSide side, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
             parameters.Add("token_id", tokenId);
-            parameters.AddEnum("side", side);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "price", PolymarketPlatform.RateLimiter.ClobApi, 1, false,
+            parameters.Add("side", side);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "price", PolymarketPlatform.RateLimiter.ClobApi, 1, false,
                 limitGuard: new SingleLimitGuard(1500, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             return await _baseClient.SendAsync<PolymarketPrice>(request, parameters, ct).ConfigureAwait(false);
         }
@@ -130,17 +133,16 @@ namespace Polymarket.Net.Clients.ClobApi
         #region Get Prices
 
         /// <inheritdoc />
-        public async Task<WebCallResult<Dictionary<string, PolymarketBuySellPrice>>> GetPricesAsync(Dictionary<string, OrderSide> tokenIds, CancellationToken ct = default)
+        public async Task<HttpResult<Dictionary<string, PolymarketBuySellPrice>>> GetPricesAsync(Dictionary<string, OrderSide> tokenIds, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.SetBody(tokenIds.Select(x =>            
+            var parameters = new Parameters(tokenIds.Select(x =>
                 new PolymarketPriceRequest
                 {
                     TokenId = x.Key,
                     Side = x.Value
                 }
-            ).ToArray());
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "prices", PolymarketPlatform.RateLimiter.ClobApi, 1, false,
+            ).ToArray(), PolymarketPlatform._parameterSerializationSettings);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "prices", PolymarketPlatform.RateLimiter.ClobApi, 1, false,
                 limitGuard: new SingleLimitGuard(500, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             return await _baseClient.SendAsync<Dictionary<string, PolymarketBuySellPrice>>(request, parameters, ct).ConfigureAwait(false);
         }
@@ -150,11 +152,11 @@ namespace Polymarket.Net.Clients.ClobApi
         #region Get Midpoint Price
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketMidPrice>> GetMidpointPriceAsync(string tokenId, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketMidPrice>> GetMidpointPriceAsync(string tokenId, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
             parameters.Add("token_id", tokenId);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "midpoint", PolymarketPlatform.RateLimiter.ClobApi, 1, false,
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "midpoint", PolymarketPlatform.RateLimiter.ClobApi, 1, false,
                 limitGuard: new SingleLimitGuard(1500, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<PolymarketMidPrice>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -165,16 +167,15 @@ namespace Polymarket.Net.Clients.ClobApi
         #region Get Midpoint Prices
 
         /// <inheritdoc />
-        public async Task<WebCallResult<Dictionary<string, decimal>>> GetMidpointPricesAsync(IEnumerable<string> tokenIds, CancellationToken ct = default)
+        public async Task<HttpResult<Dictionary<string, decimal>>> GetMidpointPricesAsync(IEnumerable<string> tokenIds, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.SetBody(tokenIds.Select(x =>
+            var parameters = new Parameters(tokenIds.Select(x =>
                 new PolymarketTokenRequest
                 {
                     TokenId = x
                 }
-            ).ToArray());
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "midpoints", PolymarketPlatform.RateLimiter.ClobApi, 1, false,
+            ).ToArray(), PolymarketPlatform._parameterSerializationSettings);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "midpoints", PolymarketPlatform.RateLimiter.ClobApi, 1, false,
                 limitGuard: new SingleLimitGuard(500, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<Dictionary<string, decimal>>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -185,18 +186,21 @@ namespace Polymarket.Net.Clients.ClobApi
         #region Get Price History
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketPriceHistory[]>> GetPriceHistoryAsync(string market, DateTime? startTime = null, DateTime? endTime = null, DataInterval? interval = null, int? fidelity = null, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketPriceHistory[]>> GetPriceHistoryAsync(string market, DateTime? startTime = null, DateTime? endTime = null, DataInterval? interval = null, int? fidelity = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
             parameters.Add("market", market);
-            parameters.AddOptionalMilliseconds("startTs", startTime);
-            parameters.AddOptionalMilliseconds("endTs", endTime);
-            parameters.AddOptionalEnum("interval", interval);
-            parameters.AddOptional("fidelity", fidelity);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "/prices-history", PolymarketPlatform.RateLimiter.ClobApi, 1, false,
+            parameters.Add("startTs", startTime);
+            parameters.Add("endTs", endTime);
+            parameters.Add("interval", interval);
+            parameters.Add("fidelity", fidelity);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "/prices-history", PolymarketPlatform.RateLimiter.ClobApi, 1, false,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<PolymarketPriceHistoryWrapper>(request, parameters, ct).ConfigureAwait(false);
-            return result.As<PolymarketPriceHistory[]>(result.Data?.History);
+            if (!result.Success)
+                return HttpResult.Fail<PolymarketPriceHistory[]>(result);
+
+            return HttpResult.Ok(result, result.Data.History);
         }
 
         #endregion
@@ -204,11 +208,11 @@ namespace Polymarket.Net.Clients.ClobApi
         #region Get Bid Ask Spread
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketSpread>> GetBidAskSpreadsAsync(string tokenId, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketSpread>> GetBidAskSpreadsAsync(string tokenId, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
             parameters.Add("token_id", tokenId);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "spread", PolymarketPlatform.RateLimiter.ClobApi, 1, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "spread", PolymarketPlatform.RateLimiter.ClobApi, 1, false);
             var result = await _baseClient.SendAsync<PolymarketSpread>(request, parameters, ct).ConfigureAwait(false);
             return result;
         }
@@ -218,16 +222,15 @@ namespace Polymarket.Net.Clients.ClobApi
         #region Get Bid Ask Spreads
 
         /// <inheritdoc />
-        public async Task<WebCallResult<Dictionary<string, decimal>>> GetBidAskSpreadsAsync(IEnumerable<string> tokenIds, CancellationToken ct = default)
+        public async Task<HttpResult<Dictionary<string, decimal>>> GetBidAskSpreadsAsync(IEnumerable<string> tokenIds, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.SetBody(tokenIds.Select(x =>
+            var parameters = new Parameters(tokenIds.Select(x =>
                 new PolymarketTokenRequest
                 {
                     TokenId = x
                 }
-            ).ToArray());
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "spreads", PolymarketPlatform.RateLimiter.ClobApi, 1, false);
+            ).ToArray(), PolymarketPlatform._parameterSerializationSettings);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "spreads", PolymarketPlatform.RateLimiter.ClobApi, 1, false);
             var result = await _baseClient.SendAsync<Dictionary<string, decimal>>(request, parameters, ct).ConfigureAwait(false);
             return result;
         }
@@ -237,11 +240,11 @@ namespace Polymarket.Net.Clients.ClobApi
         #region Get Token Info
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketOrderBook>> GetOrderBookAsync(string tokenId, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketOrderBook>> GetOrderBookAsync(string tokenId, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
             parameters.Add("token_id", tokenId);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "book", PolymarketPlatform.RateLimiter.ClobApi, 1, false,
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "book", PolymarketPlatform.RateLimiter.ClobApi, 1, false,
                 limitGuard: new SingleLimitGuard(1500, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<PolymarketOrderBook>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -252,16 +255,15 @@ namespace Polymarket.Net.Clients.ClobApi
         #region Get Token Infos
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketOrderBook[]>> GetOrderBooksAsync(IEnumerable<string> tokenIds, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketOrderBook[]>> GetOrderBooksAsync(IEnumerable<string> tokenIds, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.SetBody(tokenIds.Select(x =>
+            var parameters = new Parameters(tokenIds.Select(x =>
                 new PolymarketTokenRequest
                 {
                     TokenId = x
                 }
-            ).ToArray());
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "books", PolymarketPlatform.RateLimiter.ClobApi, 1, false,
+            ).ToArray(), PolymarketPlatform._parameterSerializationSettings);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "books", PolymarketPlatform.RateLimiter.ClobApi, 1, false,
                 limitGuard: new SingleLimitGuard(500, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<PolymarketOrderBook[]>(request, parameters, ct).ConfigureAwait(false);
             return result;
@@ -272,11 +274,11 @@ namespace Polymarket.Net.Clients.ClobApi
         #region Get Tick Size
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketTickSize>> GetTickSizeAsync(string tokenId, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketTickSize>> GetTickSizeAsync(string tokenId, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
             parameters.Add("token_id", tokenId);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "tick-size", PolymarketPlatform.RateLimiter.ClobApi, 1, false,
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "tick-size", PolymarketPlatform.RateLimiter.ClobApi, 1, false,
                 limitGuard: new SingleLimitGuard(200, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             return await _baseClient.SendAsync<PolymarketTickSize>(request, parameters, ct).ConfigureAwait(false);
         }
@@ -286,11 +288,11 @@ namespace Polymarket.Net.Clients.ClobApi
         #region Get Negative Risk
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketNegRisk>> GetNegativeRiskAsyncAsync(string tokenId, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketNegRisk>> GetNegativeRiskAsyncAsync(string tokenId, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
             parameters.Add("token_id", tokenId);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "neg-risk", PolymarketPlatform.RateLimiter.ClobApi, 1, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "neg-risk", PolymarketPlatform.RateLimiter.ClobApi, 1, false);
             return await _baseClient.SendAsync<PolymarketNegRisk>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -299,11 +301,11 @@ namespace Polymarket.Net.Clients.ClobApi
         #region Get Fee Rate Bps
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketFeeRateBps>> GetFeeRateBpsAsync(string tokenId, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketFeeRateBps>> GetFeeRateBpsAsync(string tokenId, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
             parameters.Add("token_id", tokenId);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "fee-rate", PolymarketPlatform.RateLimiter.ClobApi, 1, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "fee-rate", PolymarketPlatform.RateLimiter.ClobApi, 1, false);
             return await _baseClient.SendAsync<PolymarketFeeRateBps>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -312,11 +314,11 @@ namespace Polymarket.Net.Clients.ClobApi
         #region Get Last Trade Price
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketTradePrice>> GetLastTradePriceAsync(string tokenId, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketTradePrice>> GetLastTradePriceAsync(string tokenId, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
             parameters.Add("token_id", tokenId);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "last-trade-price", PolymarketPlatform.RateLimiter.ClobApi, 1, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "last-trade-price", PolymarketPlatform.RateLimiter.ClobApi, 1, false);
             return await _baseClient.SendAsync<PolymarketTradePrice>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -325,16 +327,15 @@ namespace Polymarket.Net.Clients.ClobApi
         #region Get Last Trade Prices
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketTradePrice[]>> GetLastTradePricesAsync(IEnumerable<string> tokenIds, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketTradePrice[]>> GetLastTradePricesAsync(IEnumerable<string> tokenIds, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.SetBody(tokenIds.Select(x =>
+            var parameters = new Parameters(tokenIds.Select(x =>
                 new PolymarketTokenRequest
                 {
                     TokenId = x
                 }
-            ).ToArray());
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "last-trades-prices", PolymarketPlatform.RateLimiter.ClobApi, 1, false);
+            ).ToArray(), PolymarketPlatform._parameterSerializationSettings);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "last-trades-prices", PolymarketPlatform.RateLimiter.ClobApi, 1, false);
             return await _baseClient.SendAsync<PolymarketTradePrice[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -343,10 +344,10 @@ namespace Polymarket.Net.Clients.ClobApi
         #region Get Market Info
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketMarketInfo>> GetMarketInfoAsync(string marketId, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketMarketInfo>> GetMarketInfoAsync(string marketId, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            var request = _definitions.GetOrCreate(HttpMethod.Get, $"/clob-markets/{marketId}", PolymarketPlatform.RateLimiter.ClobApi, 1, false);
+            var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, $"/clob-markets/{marketId}", PolymarketPlatform.RateLimiter.ClobApi, 1, false);
             var result = await _baseClient.SendAsync<PolymarketMarketInfo>(request, parameters, ct).ConfigureAwait(false);
             return result;
         }

--- a/Polymarket.Net/Clients/ClobApi/PolymarketRestClientClobApiTrading.cs
+++ b/Polymarket.Net/Clients/ClobApi/PolymarketRestClientClobApiTrading.cs
@@ -62,13 +62,23 @@ namespace Polymarket.Net.Clients.ClobApi
             long? clientOrderId = null,
             DateTime? expiration = null,
             QuantityType? quantityType = null,
+            decimal? tickQuantity = null,
+            bool? negativeRisk = null,
             CancellationToken ct = default)
         {
-            var tokenResult = await PolymarketUtils.GetTokenInfoAsync(tokenId, _baseClient).ConfigureAwait(false);
-            if (!tokenResult.Success)
-                return HttpResult.Fail<PolymarketOrderResult>(_baseClient.Exchange, tokenResult.Error);
+            PolymarketOrderBook? tokenInfo = null;
+            if (orderType != OrderType.Limit || tickQuantity is null || negativeRisk is null)
+            {
+                var tokenResult = await PolymarketUtils.GetTokenInfoAsync(tokenId, _baseClient).ConfigureAwait(false);
+                if (!tokenResult.Success)
+                    return HttpResult.Fail<PolymarketOrderResult>(PolymarketPlatform.Metadata.Id, tokenResult.Error);
 
-            var makerTakerQuantities = GetMakerTakerQuantities(tokenId, side, orderType, quantity, price, timeInForce, tokenResult.Data.TickQuantity, quantityType ?? QuantityType.Shares, tokenResult.Data);
+                tokenInfo = tokenResult.Data;
+                tickQuantity ??= tokenInfo.TickQuantity;
+                negativeRisk ??= tokenInfo.NegativeRisk;
+            }
+
+            var makerTakerQuantities = GetMakerTakerQuantities(tokenId, side, orderType, quantity, price, timeInForce, tickQuantity.Value, quantityType ?? QuantityType.Shares, tokenInfo);
             if (!makerTakerQuantities.Success)
                 return HttpResult.Fail<PolymarketOrderResult>(_baseClient.Exchange, makerTakerQuantities.Error);
 
@@ -100,7 +110,7 @@ namespace Polymarket.Net.Clients.ClobApi
                 _baseClient.AuthenticationProvider.GetOrderSignature(
                     orderParameters,
                     _baseClient.ClientOptions.Environment.ChainId,
-                    tokenResult.Data.NegativeRisk).ToLowerInvariant());
+                    negativeRisk.Value).ToLowerInvariant());
 
             parameters.Add("order", orderParameters);
             parameters.Add("owner", credentials.L2!.Key!);
@@ -121,9 +131,20 @@ namespace Polymarket.Net.Clients.ClobApi
 
         public async Task<HttpResult<CallResult<PolymarketOrderResult>[]>> PlaceMultipleOrdersAsync(IEnumerable<PolymarketOrderRequest> requests, CancellationToken ct = default)
         {
-            var tokenResult = await PolymarketUtils.GetTokenInfosAsync(requests.Select(x => x.TokenId).Distinct(), _baseClient).ConfigureAwait(false);
-            if (!tokenResult.Success)
-                return HttpResult.Fail<CallResult<PolymarketOrderResult>[]>(_baseClient.Exchange, tokenResult.Error);
+            var tokensToRequest = requests
+                .Where(x => x.OrderType != OrderType.Limit || x.TickQuantity is null || x.NegativeRisk is null)
+                .Select(x => x.TokenId)
+                .Distinct().ToList();
+
+            var orderBookInfos = new PolymarketOrderBook[0];
+            if (tokensToRequest.Count > 0)
+            {
+                var tokenResult = await PolymarketUtils.GetTokenInfosAsync(tokensToRequest, _baseClient).ConfigureAwait(false);
+                if (!tokenResult.Success)
+                    return HttpResult.Fail<CallResult<PolymarketOrderResult>[]>(_baseClient.Exchange, tokenResult.Error);
+
+                orderBookInfos = tokenResult.Data;
+            }
 
             var builderCode = _baseClient.ClientOptions.BuilderCode ?? "0x0000000000000000000000000000000000000000000000000000000000000000";
 
@@ -138,14 +159,23 @@ namespace Polymarket.Net.Clients.ClobApi
             var parameterList = new List<Parameters>();
             foreach (var request in requests)
             {
-                var tokenInfo = tokenResult.Data.SingleOrDefault(x => x.TokenId == request.TokenId);
-                if (tokenInfo == null)
+                PolymarketOrderBook? tokenInfo = null;
+                decimal? tickQuantity = request.TickQuantity;
+                bool? negativeRisk = request.NegativeRisk;
+                if (request.OrderType != OrderType.Limit || request.TickQuantity is null || request.NegativeRisk is null)
                 {
-                    return HttpResult.Fail<CallResult<PolymarketOrderResult>[]>(_baseClient.Exchange,
-                        new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, $"Token {request.TokenId} not found")));
+                    tokenInfo = orderBookInfos.SingleOrDefault(x => x.TokenId == request.TokenId);
+                    if (tokenInfo == null)
+                    {
+                        return HttpResult.Fail<CallResult<PolymarketOrderResult>[]>(_baseClient.Exchange,
+                            new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, $"Token {request.TokenId} not found")));
+                    }
+
+                    tickQuantity ??= tokenInfo.TickQuantity;
+                    negativeRisk ??= tokenInfo.NegativeRisk;
                 }
 
-                var makerTakerQuantities = GetMakerTakerQuantities(request.TokenId, request.Side, request.OrderType, request.Quantity, request.Price, request.TimeInForce, tokenInfo.TickQuantity, request.QuantityType ?? QuantityType.Shares, tokenInfo);
+                var makerTakerQuantities = GetMakerTakerQuantities(request.TokenId, request.Side, request.OrderType, request.Quantity, request.Price, request.TimeInForce, tickQuantity!.Value, request.QuantityType ?? QuantityType.Shares, tokenInfo);
                 if (!makerTakerQuantities.Success)
                     return HttpResult.Fail<CallResult<PolymarketOrderResult>[]>(_baseClient.Exchange, makerTakerQuantities.Error);
 
@@ -167,7 +197,7 @@ namespace Polymarket.Net.Clients.ClobApi
                     _baseClient.AuthenticationProvider.GetOrderSignature(
                         orderParameters,
                         _baseClient.ClientOptions.Environment.ChainId,
-                        tokenInfo.NegativeRisk).ToLowerInvariant());
+                        negativeRisk!.Value).ToLowerInvariant());
 
                 parameters.Add("order", orderParameters);
                 parameters.Add("owner", credentials.L2!.Key!);
@@ -207,10 +237,13 @@ namespace Polymarket.Net.Clients.ClobApi
             TimeInForce? timeInForce, 
             decimal tickSize,
             QuantityType quantityType,
-            PolymarketOrderBook bookInfo)
+            PolymarketOrderBook? bookInfo)
         {
             if (quantityType == QuantityType.Value && !(orderType == OrderType.Market && side == OrderSide.Buy))
                 throw new ArgumentException("QuantityType.Value can only be set for buy market orders", nameof(quantityType));
+
+            if (bookInfo == null && orderType != OrderType.Limit)
+                throw new ArgumentException("Order book info is required for non-limit orders to calculate maker/taker quantities", nameof(bookInfo));
 
             var rounding = _roundingConfig.TryGetValue(tickSize, out var config) ? config : throw new ArgumentException($"Tick size {tickSize} not mapped to rounding config");
 
@@ -227,7 +260,7 @@ namespace Polymarket.Net.Clients.ClobApi
                 {
                     decimal? marketPrice = null;
                     var sum = 0m;
-                    for (var i = bookInfo.Asks.Length - 1; i >= 0; i--)
+                    for (var i = bookInfo!.Asks.Length - 1; i >= 0; i--)
                     {
                         var ask = bookInfo.Asks[i];
                         sum += ask.Quantity;
@@ -250,7 +283,7 @@ namespace Polymarket.Net.Clients.ClobApi
                 {
                     decimal? marketPrice = null;
                     var sum = 0m;
-                    for (var i = bookInfo.Bids.Length - 1; i >= 0; i--)
+                    for (var i = bookInfo!.Bids.Length - 1; i >= 0; i--)
                     {
                         var bid = bookInfo.Bids[i];
                         sum += bid.Quantity;

--- a/Polymarket.Net/Clients/ClobApi/PolymarketRestClientClobApiTrading.cs
+++ b/Polymarket.Net/Clients/ClobApi/PolymarketRestClientClobApiTrading.cs
@@ -51,7 +51,7 @@ namespace Polymarket.Net.Clients.ClobApi
             _logger = logger;
         }
 
-        public async Task<WebCallResult<PolymarketOrderResult>> PlaceOrderAsync(
+        public async Task<HttpResult<PolymarketOrderResult>> PlaceOrderAsync(
             string tokenId,
             OrderSide side,
             OrderType orderType,
@@ -65,16 +65,16 @@ namespace Polymarket.Net.Clients.ClobApi
             CancellationToken ct = default)
         {
             var tokenResult = await PolymarketUtils.GetTokenInfoAsync(tokenId, _baseClient).ConfigureAwait(false);
-            if (!tokenResult)
-                return new WebCallResult<PolymarketOrderResult>(tokenResult.Error);
+            if (!tokenResult.Success)
+                return HttpResult.Fail<PolymarketOrderResult>(_baseClient.Exchange, tokenResult.Error);
 
             var makerTakerQuantities = GetMakerTakerQuantities(tokenId, side, orderType, quantity, price, timeInForce, tokenResult.Data.TickQuantity, quantityType ?? QuantityType.Shares, tokenResult.Data);
-            if (!makerTakerQuantities)
-                return new WebCallResult<PolymarketOrderResult>(makerTakerQuantities.Error);
+            if (!makerTakerQuantities.Success)
+                return HttpResult.Fail<PolymarketOrderResult>(_baseClient.Exchange, makerTakerQuantities.Error);
 
             var builderCode = _baseClient.ClientOptions.BuilderCode ?? "0x0000000000000000000000000000000000000000000000000000000000000000";
-            var parameters = new ParameterCollection();
-            var orderParameters = new ParameterCollection();
+            var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
+            var orderParameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
             var credentials = _baseClient.AuthenticationProvider!.ApiCredentials;
 
             var maker = credentials.L1.PolymarketFundingAddress ?? credentials.L1.GetPublicAddress();
@@ -84,16 +84,16 @@ namespace Polymarket.Net.Clients.ClobApi
                 signer = credentials.L1.PolymarketFundingAddress;
             }
 
-            orderParameters.Add("salt", (ulong)(clientOrderId ?? ExchangeHelpers.RandomLong(1000000000000, 9999999999999)));
+            orderParameters.AddRaw("salt", (ulong)(clientOrderId ?? ExchangeHelpers.RandomLong(1000000000000, 9999999999999)));
             orderParameters.Add("maker", maker);
             orderParameters.Add("signer", signer!);
             orderParameters.Add("tokenId", tokenId);
-            orderParameters.AddString("makerAmount", makerTakerQuantities.Data.MakerQuantity);
-            orderParameters.AddString("takerAmount", makerTakerQuantities.Data.TakerQuantity);
-            orderParameters.AddEnum("side", side);
-            orderParameters.AddString("expiration", (ulong)(expiration == null ? 0 : DateTimeConverter.ConvertToSeconds(expiration.Value)));
+            orderParameters.Add("makerAmount", makerTakerQuantities.Data.MakerQuantity);
+            orderParameters.Add("takerAmount", makerTakerQuantities.Data.TakerQuantity);
+            orderParameters.Add("side", side);
+            orderParameters.Add("expiration", (expiration == null ? 0 : DateTimeConverter.ConvertToSeconds(expiration.Value)).ToString());
             orderParameters.Add("signatureType", (int)credentials.L1.SignType);
-            orderParameters.AddMillisecondsString("timestamp", DateTime.UtcNow);
+            orderParameters.Add("timestamp", DateTime.UtcNow);
             orderParameters.Add("metadata", "0x0000000000000000000000000000000000000000000000000000000000000000");
             orderParameters.Add("builder", builderCode!);
             orderParameters.Add("signature",
@@ -104,26 +104,26 @@ namespace Polymarket.Net.Clients.ClobApi
 
             parameters.Add("order", orderParameters);
             parameters.Add("owner", credentials.L2!.Key!);
-            parameters.AddEnum("orderType", timeInForce ?? (orderType == OrderType.Limit ? TimeInForce.GoodTillCanceled : TimeInForce.ImmediateOrCancel));
-            parameters.AddOptional("postOnly", postOnly);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/order", PolymarketPlatform.RateLimiter.ClobApi, 1, true,
+            parameters.Add("orderType", timeInForce ?? (orderType == OrderType.Limit ? TimeInForce.GoodTillCanceled : TimeInForce.ImmediateOrCancel));
+            parameters.Add("postOnly", postOnly);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/order", PolymarketPlatform.RateLimiter.ClobApi, 1, true,
                 limitGuard: new SingleLimitGuard(3500, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<PolymarketOrderResult>(request, parameters, ct).ConfigureAwait(false);
 
-            if (!result)
+            if (!result.Success)
                 return result;
 
             if (!string.IsNullOrEmpty(result.Data.Error))
-                return result.AsError<PolymarketOrderResult>(new ServerError(_baseClient.GetErrorInfo(result.Data.Error!, result.Data.Error)));
+                return HttpResult.Fail<PolymarketOrderResult>(result, new ServerError(_baseClient.GetErrorInfo(result.Data.Error!, result.Data.Error)));
 
             return result;
         }
 
-        public async Task<WebCallResult<CallResult<PolymarketOrderResult>[]>> PlaceMultipleOrdersAsync(IEnumerable<PolymarketOrderRequest> requests, CancellationToken ct = default)
+        public async Task<HttpResult<CallResult<PolymarketOrderResult>[]>> PlaceMultipleOrdersAsync(IEnumerable<PolymarketOrderRequest> requests, CancellationToken ct = default)
         {
             var tokenResult = await PolymarketUtils.GetTokenInfosAsync(requests.Select(x => x.TokenId).Distinct(), _baseClient).ConfigureAwait(false);
-            if (!tokenResult)
-                return new WebCallResult<CallResult<PolymarketOrderResult>[]>(tokenResult.Error);
+            if (!tokenResult.Success)
+                return HttpResult.Fail<CallResult<PolymarketOrderResult>[]>(_baseClient.Exchange, tokenResult.Error);
 
             var builderCode = _baseClient.ClientOptions.BuilderCode ?? "0x0000000000000000000000000000000000000000000000000000000000000000";
 
@@ -135,33 +135,33 @@ namespace Polymarket.Net.Clients.ClobApi
             {
                 signer = credentials.L1.PolymarketFundingAddress;
             }
-            var parameterList = new List<ParameterCollection>();
+            var parameterList = new List<Parameters>();
             foreach (var request in requests)
             {
                 var tokenInfo = tokenResult.Data.SingleOrDefault(x => x.TokenId == request.TokenId);
                 if (tokenInfo == null)
                 {
-                    return new WebCallResult<CallResult<PolymarketOrderResult>[]>(
+                    return HttpResult.Fail<CallResult<PolymarketOrderResult>[]>(_baseClient.Exchange,
                         new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, $"Token {request.TokenId} not found")));
                 }
 
                 var makerTakerQuantities = GetMakerTakerQuantities(request.TokenId, request.Side, request.OrderType, request.Quantity, request.Price, request.TimeInForce, tokenInfo.TickQuantity, request.QuantityType ?? QuantityType.Shares, tokenInfo);
-                if (!makerTakerQuantities)
-                    return new WebCallResult<CallResult<PolymarketOrderResult>[]>(makerTakerQuantities.Error);
+                if (!makerTakerQuantities.Success)
+                    return HttpResult.Fail<CallResult<PolymarketOrderResult>[]>(_baseClient.Exchange, makerTakerQuantities.Error);
 
-                var parameters = new ParameterCollection();
-                var orderParameters = new ParameterCollection();
-                orderParameters.Add("salt", (ulong)(request.ClientOrderId ?? ExchangeHelpers.RandomLong(1000000000000, 9999999999999)));
+                var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
+                var orderParameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
+                orderParameters.AddRaw("salt", (ulong)(request.ClientOrderId ?? ExchangeHelpers.RandomLong(1000000000000, 9999999999999)));
                 orderParameters.Add("maker", maker);
                 orderParameters.Add("signer", signer!);
                 orderParameters.Add("tokenId", request.TokenId);
-                orderParameters.AddString("makerAmount", makerTakerQuantities.Data.MakerQuantity);
-                orderParameters.AddString("takerAmount", makerTakerQuantities.Data.TakerQuantity);
-                orderParameters.AddString("expiration", (ulong)(request.Expiration == null ? 0 : DateTimeConverter.ConvertToSeconds(request.Expiration.Value)));
-                orderParameters.AddMillisecondsString("timestamp", DateTime.UtcNow);
+                orderParameters.Add("makerAmount", makerTakerQuantities.Data.MakerQuantity);
+                orderParameters.Add("takerAmount", makerTakerQuantities.Data.TakerQuantity);
+                orderParameters.Add("expiration", (request.Expiration == null ? 0 : DateTimeConverter.ConvertToSeconds(request.Expiration.Value)).ToString());
+                orderParameters.Add("timestamp", DateTime.UtcNow);
                 orderParameters.Add("metadata", "0x0000000000000000000000000000000000000000000000000000000000000000");
                 orderParameters.Add("builder", builderCode!);
-                orderParameters.AddEnum("side", request.Side);
+                orderParameters.Add("side", request.Side);
                 orderParameters.Add("signatureType", (int)credentials.L1.SignType);
                 orderParameters.Add("signature",
                     _baseClient.AuthenticationProvider.GetOrderSignature(
@@ -171,32 +171,31 @@ namespace Polymarket.Net.Clients.ClobApi
 
                 parameters.Add("order", orderParameters);
                 parameters.Add("owner", credentials.L2!.Key!);
-                parameters.AddEnum("orderType", request.TimeInForce ?? TimeInForce.GoodTillCanceled);
-                parameters.AddOptional("postOnly", request.PostOnly);
+                parameters.Add("orderType", request.TimeInForce ?? TimeInForce.GoodTillCanceled);
+                parameters.Add("postOnly", request.PostOnly);
                 parameterList.Add(parameters);
             }
 
-            var requestParams = new ParameterCollection();
-            requestParams.SetBody(parameterList.ToArray());
-            var requestDef = _definitions.GetOrCreate(HttpMethod.Post, "/orders", PolymarketPlatform.RateLimiter.ClobApi, 1, true,
+            var requestParams = new Parameters(parameterList.ToArray(), PolymarketPlatform._parameterSerializationSettings);
+            var requestDef = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/orders", PolymarketPlatform.RateLimiter.ClobApi, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<PolymarketOrderResult[]>(requestDef, requestParams, ct).ConfigureAwait(false);
-            if (!result)
-                return result.As<CallResult<PolymarketOrderResult>[]>(default);
+            if (!result.Success)
+                return HttpResult.Fail<CallResult<PolymarketOrderResult>[]>(result);
 
             var ordersResult = new List<CallResult<PolymarketOrderResult>>();
             foreach (var item in result.Data)
             {
                 if (!string.IsNullOrEmpty(item.Error))
-                    ordersResult.Add(new CallResult<PolymarketOrderResult>(item, null, new ServerError(_baseClient.GetErrorInfo(item.Error!, item.Error))));
+                    ordersResult.Add(CallResult.Fail<PolymarketOrderResult>(new ServerError(_baseClient.GetErrorInfo(item.Error!, item.Error))));
                 else
-                    ordersResult.Add(new CallResult<PolymarketOrderResult>(item));
+                    ordersResult.Add(CallResult.Ok(item));
             }
 
             if (ordersResult.All(x => !x.Success))
-                return result.AsErrorWithData(new ServerError(new ErrorInfo(ErrorType.AllOrdersFailed, "All orders failed")), ordersResult.ToArray());
+                return HttpResult.Fail<CallResult<PolymarketOrderResult>[]>(result, new ServerError(new ErrorInfo(ErrorType.AllOrdersFailed, "All orders failed")), ordersResult.ToArray());
 
-            return result.As(ordersResult.ToArray());
+            return HttpResult.Ok(result, ordersResult.ToArray());
         }
 
         private CallResult<(decimal MakerQuantity, decimal TakerQuantity)> GetMakerTakerQuantities(
@@ -240,10 +239,10 @@ namespace Polymarket.Net.Clients.ClobApi
                     }
 
                     if (timeInForce == TimeInForce.FillOrKill && marketPrice == null)
-                        return new WebCallResult<(decimal, decimal)>(new ServerError(new ErrorInfo(ErrorType.RejectedOrderConfiguration, "FOK order couldn't fill")));
+                        return CallResult.Fail<(decimal, decimal)>(new ServerError(new ErrorInfo(ErrorType.RejectedOrderConfiguration, "FOK order couldn't fill")));
 
                     if (marketPrice == null && bookInfo.Asks.Length == 0)
-                        return new WebCallResult<(decimal, decimal)>(new ServerError(new ErrorInfo(ErrorType.RejectedOrderConfiguration, "Market order couldn't be filled due to empty order book")));
+                        return CallResult.Fail<(decimal, decimal)>(new ServerError(new ErrorInfo(ErrorType.RejectedOrderConfiguration, "Market order couldn't be filled due to empty order book")));
 
                     price = marketPrice ?? bookInfo.Asks[0].Price;
                 }
@@ -263,10 +262,10 @@ namespace Polymarket.Net.Clients.ClobApi
                     }
 
                     if (timeInForce == TimeInForce.FillOrKill && marketPrice == null)
-                        return new WebCallResult<(decimal, decimal)>(new ServerError(new ErrorInfo(ErrorType.RejectedOrderConfiguration, "FOK order couldn't fill")));
+                        return CallResult.Fail<(decimal, decimal)>(new ServerError(new ErrorInfo(ErrorType.RejectedOrderConfiguration, "FOK order couldn't fill")));
 
                     if (marketPrice == null && bookInfo.Bids.Length == 0)
-                        return new WebCallResult<(decimal, decimal)>(new ServerError(new ErrorInfo(ErrorType.RejectedOrderConfiguration, "Market order couldn't be filled due to empty order book")));
+                        return CallResult.Fail<(decimal, decimal)>(new ServerError(new ErrorInfo(ErrorType.RejectedOrderConfiguration, "Market order couldn't be filled due to empty order book")));
 
                     price = marketPrice ?? bookInfo.Bids[0].Price;
                 }
@@ -337,7 +336,7 @@ namespace Polymarket.Net.Clients.ClobApi
             takerQuantity = takerQuantity.Normalize();
             makerQuantity = makerQuantity.Normalize();
 
-            return new CallResult<(decimal, decimal)>((makerQuantity, takerQuantity));
+            return CallResult.Ok((makerQuantity, takerQuantity));
         }
 
         private static decimal RoundUp(decimal value, int digits)
@@ -358,93 +357,91 @@ namespace Polymarket.Net.Clients.ClobApi
             return Math.Floor(value * factor) / factor;
         }
 
-        public async Task<WebCallResult<PolymarketOrder>> GetOrderAsync(string orderId, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketOrder>> GetOrderAsync(string orderId, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "/data/order/" + orderId, PolymarketPlatform.RateLimiter.ClobApi, 1, true,
+            var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "/data/order/" + orderId, PolymarketPlatform.RateLimiter.ClobApi, 1, true,
                 limitGuard: new SingleLimitGuard(900, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<PolymarketOrder>(request, parameters, ct).ConfigureAwait(false);
             return result;
         }
 
-        public async Task<WebCallResult<PolymarketPage<PolymarketOrder>>> GetOpenOrdersAsync(
+        public async Task<HttpResult<PolymarketPage<PolymarketOrder>>> GetOpenOrdersAsync(
             string? orderId = null,
             string? marketId = null,
             string? tokenId = null,
             string? cursor = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("id", orderId);
-            parameters.AddOptional("market", marketId);
-            parameters.AddOptional("asset_id", tokenId);
-            parameters.AddOptional("next_cursor", cursor);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "/data/orders", PolymarketPlatform.RateLimiter.ClobApi, 1, true,
+            var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
+            parameters.Add("id", orderId);
+            parameters.Add("market", marketId);
+            parameters.Add("asset_id", tokenId);
+            parameters.Add("next_cursor", cursor);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "/data/orders", PolymarketPlatform.RateLimiter.ClobApi, 1, true,
                 limitGuard: new SingleLimitGuard(500, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<PolymarketPage<PolymarketOrder>>(request, parameters, ct).ConfigureAwait(false);
             return result;
         }
 
-        public async Task<WebCallResult<PolymarketOrderScoring>> GetOrderRewardScoringAsync(string orderId, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketOrderScoring>> GetOrderRewardScoringAsync(string orderId, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
             parameters.Add("order_id", orderId);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "/order-scoring", PolymarketPlatform.RateLimiter.ClobApi, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "/order-scoring", PolymarketPlatform.RateLimiter.ClobApi, 1, true);
             var result = await _baseClient.SendAsync<PolymarketOrderScoring>(request, parameters, ct).ConfigureAwait(false);
             return result;
         }
 
 
-        public async Task<WebCallResult<Dictionary<string, bool>>> GetOrdersRewardScoringAsync(IEnumerable<string> orderIds, CancellationToken ct = default)
+        public async Task<HttpResult<Dictionary<string, bool>>> GetOrdersRewardScoringAsync(IEnumerable<string> orderIds, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.SetBody(orderIds.ToArray());
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/orders-scoring", PolymarketPlatform.RateLimiter.ClobApi, 1, true);
+            var parameters = new Parameters(orderIds.ToArray(), PolymarketPlatform._parameterSerializationSettings);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/orders-scoring", PolymarketPlatform.RateLimiter.ClobApi, 1, true);
             var result = await _baseClient.SendAsync<Dictionary<string, bool>>(request, parameters, ct).ConfigureAwait(false);
             return result;
         }
 
-        public async Task<WebCallResult<PolymarketCancelResult>> CancelOrderAsync(string orderId, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketCancelResult>> CancelOrderAsync(string orderId, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
             parameters.Add("orderID", orderId);
-            var request = _definitions.GetOrCreate(HttpMethod.Delete, "/order", PolymarketPlatform.RateLimiter.ClobApi, 1, true,
+            var request = _definitions.GetOrCreate(HttpMethod.Delete, _baseClient.BaseAddress, "/order", PolymarketPlatform.RateLimiter.ClobApi, 1, true,
                 limitGuard: new SingleLimitGuard(3000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<PolymarketCancelResult>(request, parameters, ct).ConfigureAwait(false);
             return result;
         }
 
-        public async Task<WebCallResult<PolymarketCancelResult>> CancelOrdersAsync(IEnumerable<string> orderIds, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketCancelResult>> CancelOrdersAsync(IEnumerable<string> orderIds, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.SetBody(orderIds.ToArray());
-            var request = _definitions.GetOrCreate(HttpMethod.Delete, "/orders", PolymarketPlatform.RateLimiter.ClobApi, 1, true,
+            var parameters = new Parameters(orderIds.ToArray(), PolymarketPlatform._parameterSerializationSettings);
+            var request = _definitions.GetOrCreate(HttpMethod.Delete, _baseClient.BaseAddress, "/orders", PolymarketPlatform.RateLimiter.ClobApi, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<PolymarketCancelResult>(request, parameters, ct).ConfigureAwait(false);
             return result;
         }
 
-        public async Task<WebCallResult<PolymarketCancelResult>> CancelOrdersOnMarketAsync(string? market = null, string? tokenId = null, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketCancelResult>> CancelOrdersOnMarketAsync(string? market = null, string? tokenId = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("market", market);
-            parameters.AddOptional("asset_id", tokenId);
-            var request = _definitions.GetOrCreate(HttpMethod.Delete, "/cancel-market-orders", PolymarketPlatform.RateLimiter.ClobApi, 1, true,
+            var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
+            parameters.Add("market", market);
+            parameters.Add("asset_id", tokenId);
+            var request = _definitions.GetOrCreate(HttpMethod.Delete, _baseClient.BaseAddress, "/cancel-market-orders", PolymarketPlatform.RateLimiter.ClobApi, 1, true,
                 limitGuard: new SingleLimitGuard(1000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<PolymarketCancelResult>(request, parameters, ct).ConfigureAwait(false);
             return result;
         }
 
-        public async Task<WebCallResult<PolymarketCancelResult>> CancelAllOrdersAsync(CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketCancelResult>> CancelAllOrdersAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            var request = _definitions.GetOrCreate(HttpMethod.Delete, "/cancel-all", PolymarketPlatform.RateLimiter.ClobApi, 1, true,
+            var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
+            var request = _definitions.GetOrCreate(HttpMethod.Delete, _baseClient.BaseAddress, "/cancel-all", PolymarketPlatform.RateLimiter.ClobApi, 1, true,
                 limitGuard: new SingleLimitGuard(250, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<PolymarketCancelResult>(request, parameters, ct).ConfigureAwait(false);
             return result;
         }
 
-        public async Task<WebCallResult<PolymarketPage<PolymarketTrade>>> GetUserTradesAsync(
+        public async Task<HttpResult<PolymarketPage<PolymarketTrade>>> GetUserTradesAsync(
             string? tradeId = null,
             string? makerAddress = null,
             string? marketId = null,
@@ -454,25 +451,25 @@ namespace Polymarket.Net.Clients.ClobApi
             string? cursor = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("id", tradeId);
-            parameters.AddOptional("maker_address", makerAddress);
-            parameters.AddOptional("market", marketId);
-            parameters.AddOptional("asset_id", tokenId);
-            parameters.AddOptionalMillisecondsString("after", startTime);
-            parameters.AddOptionalMillisecondsString("before", endTime);
-            parameters.AddOptional("next_cursor", cursor);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "/trades", PolymarketPlatform.RateLimiter.ClobApi, 1, true,
+            var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
+            parameters.Add("id", tradeId);
+            parameters.Add("maker_address", makerAddress);
+            parameters.Add("market", marketId);
+            parameters.Add("asset_id", tokenId);
+            parameters.Add("after", startTime);
+            parameters.Add("before", endTime);
+            parameters.Add("next_cursor", cursor);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "/trades", PolymarketPlatform.RateLimiter.ClobApi, 1, true,
                 limitGuard: new SingleLimitGuard(500, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             var result = await _baseClient.SendAsync<PolymarketPage<PolymarketTrade>>(request, parameters, ct).ConfigureAwait(false);
             return result;
         }
 
-        public async Task<WebCallResult> PostOrderHeartbeatAsync(CancellationToken ct = default)
+        public async Task<HttpResult> PostOrderHeartbeatAsync(CancellationToken ct = default)
         {
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "/heartbeats", PolymarketPlatform.RateLimiter.ClobApi, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/heartbeats", PolymarketPlatform.RateLimiter.ClobApi, 1, true);
             var result = await _baseClient.SendAsync<PolymarketOrderHeartbeat>(request, null, ct).ConfigureAwait(false);
-            return result.AsDataless();
+            return result;
         }
 
         private static int GetDecimalPlaces(decimal value)

--- a/Polymarket.Net/Clients/ClobApi/PolymarketSocketClientClobApi.cs
+++ b/Polymarket.Net/Clients/ClobApi/PolymarketSocketClientClobApi.cs
@@ -44,8 +44,8 @@ namespace Polymarket.Net.Clients.ClobApi
         /// <summary>
         /// ctor
         /// </summary>
-        internal PolymarketSocketClientClobApi(ILogger logger, PolymarketSocketOptions options) :
-            base(logger, PolymarketPlatform.Metadata.Id, options.Environment.ClobSocketClientAddress!, options, options.ClobOptions)
+        internal PolymarketSocketClientClobApi(ILoggerFactory? loggerFactory, PolymarketSocketOptions options) :
+            base(loggerFactory, PolymarketPlatform.Metadata.Id, options.Environment.ClobSocketClientAddress!, options, options.ClobOptions)
         {
             AddSystemSubscription(new PolymarketGeneralSystemSubscription(_logger));
 

--- a/Polymarket.Net/Clients/ClobApi/PolymarketSocketClientClobApi.cs
+++ b/Polymarket.Net/Clients/ClobApi/PolymarketSocketClientClobApi.cs
@@ -45,7 +45,7 @@ namespace Polymarket.Net.Clients.ClobApi
         /// ctor
         /// </summary>
         internal PolymarketSocketClientClobApi(ILogger logger, PolymarketSocketOptions options) :
-            base(logger, options.Environment.ClobSocketClientAddress!, options, options.ClobOptions)
+            base(logger, PolymarketPlatform.Metadata.Id, options.Environment.ClobSocketClientAddress!, options, options.ClobOptions)
         {
             AddSystemSubscription(new PolymarketGeneralSystemSubscription(_logger));
 
@@ -77,7 +77,7 @@ namespace Polymarket.Net.Clients.ClobApi
             => new PolymarketAuthenticationProvider(credentials);
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToPlatformUpdatesAsync(
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToPlatformUpdatesAsync(
             Action<DataEvent<PolymarketNewMarketUpdate>>? onNewMarketUpdate = null,
             Action<DataEvent<PolymarketMarketResolvedUpdate>>? onMarketResolvedUpdate = null,
             CancellationToken ct = default)
@@ -91,7 +91,7 @@ namespace Polymarket.Net.Clients.ClobApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToTokenUpdatesAsync(
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToTokenUpdatesAsync(
             IEnumerable<string> assetIds,
             Action<DataEvent<PolymarketPriceChangeUpdate>>? onPriceChangeUpdate = null, 
             Action<DataEvent<PolymarketBookUpdate>>? onBookUpdate = null,
@@ -113,7 +113,7 @@ namespace Polymarket.Net.Clients.ClobApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToUserUpdatesAsync(
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToUserUpdatesAsync(
             Action<DataEvent<PolymarketOrderUpdate>>? onOrderUpdate = null,
             Action<DataEvent<PolymarketTradeUpdate>>? onTradeUpdate = null,
             CancellationToken ct = default)
@@ -127,7 +127,7 @@ namespace Polymarket.Net.Clients.ClobApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToSportsUpdatesAsync(
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToSportsUpdatesAsync(
             Action<DataEvent<PolymarketSportsUpdate>>? onSportsUpdate = null,
             CancellationToken ct = default)
         {

--- a/Polymarket.Net/Clients/DataApi/PolymarketRestClientDataApi.cs
+++ b/Polymarket.Net/Clients/DataApi/PolymarketRestClientDataApi.cs
@@ -35,8 +35,8 @@ namespace Polymarket.Net.Clients.DataApi
         #endregion
 
         #region constructor/destructor
-        internal PolymarketRestClientDataApi(ILogger logger, HttpClient? httpClient, PolymarketRestOptions options)
-            : base(logger, PolymarketPlatform.Metadata.Id, httpClient, options.Environment.DataRestClientAddress, options, options.DataOptions) {
+        internal PolymarketRestClientDataApi(ILoggerFactory? loggerFactory, HttpClient? httpClient, PolymarketRestOptions options)
+            : base(loggerFactory, PolymarketPlatform.Metadata.Id, httpClient, options.Environment.DataRestClientAddress, options, options.DataOptions) {
             RequestBodyEmptyContent = "";
         }
         #endregion

--- a/Polymarket.Net/Clients/DataApi/PolymarketRestClientDataApi.cs
+++ b/Polymarket.Net/Clients/DataApi/PolymarketRestClientDataApi.cs
@@ -36,11 +36,8 @@ namespace Polymarket.Net.Clients.DataApi
 
         #region constructor/destructor
         internal PolymarketRestClientDataApi(ILogger logger, HttpClient? httpClient, PolymarketRestOptions options)
-            : base(logger, httpClient, options.Environment.DataRestClientAddress, options, options.DataOptions) {
+            : base(logger, PolymarketPlatform.Metadata.Id, httpClient, options.Environment.DataRestClientAddress, options, options.DataOptions) {
             RequestBodyEmptyContent = "";
-            ArraySerialization = ArrayParametersSerialization.MultipleValues;
-
-            OrderParameters = false;
         }
         #endregion
 
@@ -51,19 +48,13 @@ namespace Polymarket.Net.Clients.DataApi
         protected override PolymarketAuthenticationProvider CreateAuthenticationProvider(PolymarketCredentials credentials)
             => new PolymarketAuthenticationProvider(credentials);
 
-        internal Task<WebCallResult> SendAsync(RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null)
-            => SendToAddressAsync(BaseAddress, definition, parameters, cancellationToken, weight);
-
-        internal async Task<WebCallResult> SendToAddressAsync(string baseAddress, RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null) {
-            var result = await base.SendAsync(baseAddress, definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
+        internal async Task<HttpResult> SendAsync(RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null) {
+            var result = await base.SendAsync<Unit>(definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
             return result;
         }
 
-        internal Task<WebCallResult<T>> SendAsync<T>(RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null)
-            => SendToAddressAsync<T>(BaseAddress, definition, parameters, cancellationToken, weight);
-
-        internal async Task<WebCallResult<T>> SendToAddressAsync<T>(string baseAddress, RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null) {
-            var result = await base.SendAsync<T>(baseAddress, definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
+        internal async Task<HttpResult<T>> SendAsync<T>(RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null) {
+            var result = await base.SendAsync<T>(definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
             return result;
         }
 
@@ -71,11 +62,11 @@ namespace Polymarket.Net.Clients.DataApi
         public override string FormatSymbol(string baseAsset, string quoteAsset, TradingMode tradingMode, DateTime? deliverDate = null)
             => throw new NotImplementedException();
 
-        public async Task<WebCallResult<PolymarketPosition[]>> GetPositionsAsync(string user, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketPosition[]>> GetPositionsAsync(string user, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(PolymarketPlatform._parameterSerializationSettings);
             parameters.Add("user", user);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "positions", PolymarketPlatform.RateLimiter.DataApi, 1, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, BaseAddress, "positions", PolymarketPlatform.RateLimiter.DataApi, 1, false);
             return await SendAsync<PolymarketPosition[]>(request, parameters, ct).ConfigureAwait(false);
         }
     }

--- a/Polymarket.Net/Clients/GammaApi/PolymarketRestClientGammaApi.cs
+++ b/Polymarket.Net/Clients/GammaApi/PolymarketRestClientGammaApi.cs
@@ -18,6 +18,7 @@ using Polymarket.Net.Objects.Models;
 using System.Collections.Generic;
 using Polymarket.Net.Enums;
 using CryptoExchange.Net.RateLimiting.Guards;
+using System.Linq;
 
 namespace Polymarket.Net.Clients.GammaApi
 {
@@ -42,13 +43,10 @@ namespace Polymarket.Net.Clients.GammaApi
 
         #region constructor/destructor
         internal PolymarketRestClientGammaApi(ILogger logger, HttpClient? httpClient, PolymarketRestOptions options)
-            : base(logger, httpClient, options.Environment.GammaRestClientAddress, options, options.GammaOptions)
+            : base(logger, PolymarketPlatform.Metadata.Id, httpClient, options.Environment.GammaRestClientAddress, options, options.GammaOptions)
         {
             RequestBodyEmptyContent = "";
             ParameterPositions[HttpMethod.Delete] = HttpMethodParameterPosition.InBody;
-            ArraySerialization = ArrayParametersSerialization.MultipleValues;
-
-            OrderParameters = false;
         }
         #endregion
 
@@ -60,26 +58,20 @@ namespace Polymarket.Net.Clients.GammaApi
         protected override PolymarketAuthenticationProvider CreateAuthenticationProvider(PolymarketCredentials credentials)
             => new PolymarketAuthenticationProvider(credentials);
 
-        internal Task<WebCallResult> SendAsync(RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null)
-            => SendToAddressAsync(BaseAddress, definition, parameters, cancellationToken, weight);
-
-        internal async Task<WebCallResult> SendToAddressAsync(string baseAddress, RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null)
+        internal async Task<HttpResult> SendAsync(RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null)
         {
-            var result = await base.SendAsync(baseAddress, definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
+            var result = await base.SendAsync<Unit>(definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
             return result;
         }
 
-        internal Task<WebCallResult<T>> SendAsync<T>(RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null)
-            => SendToAddressAsync<T>(BaseAddress, definition, parameters, cancellationToken, weight);
-
-        internal async Task<WebCallResult<T>> SendToAddressAsync<T>(string baseAddress, RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null)
+        internal async Task<HttpResult<T>> SendAsync<T>(RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null)
         {
-            var result = await base.SendAsync<T>(baseAddress, definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
+            var result = await base.SendAsync<T>(definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
             return result;
         }
 
         /// <inheritdoc />
-        protected override Task<WebCallResult<DateTime>> GetServerTimestampAsync() => throw new NotImplementedException();
+        protected override Task<HttpResult<DateTime>> GetServerTimestampAsync() => throw new NotImplementedException();
 
         /// <inheritdoc />
         public override string FormatSymbol(string baseAsset, string quoteAsset, TradingMode tradingMode, DateTime? deliverDate = null)
@@ -88,7 +80,7 @@ namespace Polymarket.Net.Clients.GammaApi
         #region Get Sport Teams
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketSportsTeam[]>> GetSportTeamsAsync(
+        public async Task<HttpResult<PolymarketSportsTeam[]>> GetSportTeamsAsync(
             IEnumerable<string>? league = null,
             IEnumerable<string>? name = null,
             IEnumerable<string>? abbreviation = null,
@@ -98,15 +90,15 @@ namespace Polymarket.Net.Clients.GammaApi
             bool? ascending = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptionalCommaSeparated("order", orderBy);
-            parameters.AddOptional("league", league);
-            parameters.AddOptional("name", name);
-            parameters.AddOptional("abbreviation", abbreviation);
-            parameters.AddOptionalBoolString("ascending", ascending);
+            var parameters = new Parameters(PolymarketPlatform._gammaParameterSerializationSettings);
+            parameters.AddCommaSeparated("order", orderBy);
+            parameters.AddRaw("league", league?.ToArray());
+            parameters.AddRaw("name", name?.ToArray());
+            parameters.AddRaw("abbreviation", abbreviation?.ToArray());
+            parameters.Add("ascending", ascending);
             parameters.Add("limit", limit ?? 20);
             parameters.Add("offset", offset ?? 0);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "teams", PolymarketPlatform.RateLimiter.GammaApi, 1, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, BaseAddress, "teams", PolymarketPlatform.RateLimiter.GammaApi, 1, false);
             return await SendAsync<PolymarketSportsTeam[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -115,10 +107,10 @@ namespace Polymarket.Net.Clients.GammaApi
         #region Get Sports
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketSport[]>> GetSportsAsync(CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketSport[]>> GetSportsAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "sports", PolymarketPlatform.RateLimiter.GammaApi, 1, false);
+            var parameters = new Parameters(PolymarketPlatform._gammaParameterSerializationSettings);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, BaseAddress, "sports", PolymarketPlatform.RateLimiter.GammaApi, 1, false);
             return await SendAsync<PolymarketSport[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -127,12 +119,15 @@ namespace Polymarket.Net.Clients.GammaApi
         #region Get Sport Market Types
 
         /// <inheritdoc />
-        public async Task<WebCallResult<string[]>> GetSportMarketTypesAsync(CancellationToken ct = default)
+        public async Task<HttpResult<string[]>> GetSportMarketTypesAsync(CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "sports/market-types", PolymarketPlatform.RateLimiter.GammaApi, 1, false);
+            var parameters = new Parameters(PolymarketPlatform._gammaParameterSerializationSettings);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, BaseAddress, "sports/market-types", PolymarketPlatform.RateLimiter.GammaApi, 1, false);
             var result = await SendAsync<PolymarketSportMarketTypes>(request, parameters, ct).ConfigureAwait(false);
-            return result.As<string[]>(result.Data?.MarketTypes);
+            if (!result.Success)
+                return HttpResult.Fail<string[]>(result);
+
+            return HttpResult.Ok(result, result.Data.MarketTypes);
         }
 
         #endregion
@@ -140,7 +135,7 @@ namespace Polymarket.Net.Clients.GammaApi
         #region Get Tags
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketTag[]>> GetTagsAsync(
+        public async Task<HttpResult<PolymarketTag[]>> GetTagsAsync(
             bool? includeTemplate = null,
             bool? isCarousel = null,
             int? limit = null,
@@ -149,14 +144,14 @@ namespace Polymarket.Net.Clients.GammaApi
             bool? ascending = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptionalCommaSeparated("order", orderBy);
-            parameters.AddOptionalBoolString("includeTemplate", includeTemplate);
-            parameters.AddOptionalBoolString("isCarousel", isCarousel);
-            parameters.AddOptionalBoolString("ascending", ascending);
+            var parameters = new Parameters(PolymarketPlatform._gammaParameterSerializationSettings);
+            parameters.AddCommaSeparated("order", orderBy);
+            parameters.Add("includeTemplate", includeTemplate);
+            parameters.Add("isCarousel", isCarousel);
+            parameters.Add("ascending", ascending);
             parameters.Add("limit", limit ?? 20);
             parameters.Add("offset", offset ?? 0);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "tags", PolymarketPlatform.RateLimiter.GammaApi, 1, false,
+            var request = _definitions.GetOrCreate(HttpMethod.Get, BaseAddress, "tags", PolymarketPlatform.RateLimiter.GammaApi, 1, false,
                 limitGuard: new SingleLimitGuard(200, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             return await SendAsync<PolymarketTag[]>(request, parameters, ct).ConfigureAwait(false);
         }
@@ -166,11 +161,11 @@ namespace Polymarket.Net.Clients.GammaApi
         #region Get Tag By Id
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketTag>> GetTagByIdAsync(string id, bool? includeTemplate = null, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketTag>> GetTagByIdAsync(string id, bool? includeTemplate = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptionalBoolString("includeTemplate", includeTemplate);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "tags/" + id, PolymarketPlatform.RateLimiter.GammaApi, 1, false);
+            var parameters = new Parameters(PolymarketPlatform._gammaParameterSerializationSettings);
+            parameters.Add("includeTemplate", includeTemplate);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, BaseAddress, "tags/" + id, PolymarketPlatform.RateLimiter.GammaApi, 1, false);
             return await SendAsync<PolymarketTag>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -179,11 +174,11 @@ namespace Polymarket.Net.Clients.GammaApi
         #region Get Tag By Slug
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketTag>> GetTagBySlugAsync(string slug, bool? includeTemplate = null, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketTag>> GetTagBySlugAsync(string slug, bool? includeTemplate = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptionalBoolString("includeTemplate", includeTemplate);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "tags/slug/" + slug, PolymarketPlatform.RateLimiter.GammaApi, 1, false);
+            var parameters = new Parameters(PolymarketPlatform._gammaParameterSerializationSettings);
+            parameters.Add("includeTemplate", includeTemplate);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, BaseAddress, "tags/slug/" + slug, PolymarketPlatform.RateLimiter.GammaApi, 1, false);
             return await SendAsync<PolymarketTag>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -192,12 +187,12 @@ namespace Polymarket.Net.Clients.GammaApi
         #region Get Related Tags By Id
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketRelatedTag[]>> GetRelatedTagsByIdAsync(string id, bool? omitEmpty = null, TagStatus? status = null, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketRelatedTag[]>> GetRelatedTagsByIdAsync(string id, bool? omitEmpty = null, TagStatus? status = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptionalBoolString("includeTemplate", omitEmpty);
-            parameters.AddOptionalEnum("status", status);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, $"tags/{id}/related-tags", PolymarketPlatform.RateLimiter.GammaApi, 1, false);
+            var parameters = new Parameters(PolymarketPlatform._gammaParameterSerializationSettings);
+            parameters.Add("includeTemplate", omitEmpty);
+            parameters.Add("status", status);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, BaseAddress, $"tags/{id}/related-tags", PolymarketPlatform.RateLimiter.GammaApi, 1, false);
             return await SendAsync<PolymarketRelatedTag[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -206,12 +201,12 @@ namespace Polymarket.Net.Clients.GammaApi
         #region Get Related Tags By Slug
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketRelatedTag[]>> GetRelatedTagsBySlugAsync(string slug, bool? omitEmpty = null, TagStatus? status = null, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketRelatedTag[]>> GetRelatedTagsBySlugAsync(string slug, bool? omitEmpty = null, TagStatus? status = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptionalBoolString("includeTemplate", omitEmpty);
-            parameters.AddOptionalEnum("status", status);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, $"tags/slug/{slug}/related-tags", PolymarketPlatform.RateLimiter.GammaApi, 1, false);
+            var parameters = new Parameters(PolymarketPlatform._gammaParameterSerializationSettings);
+            parameters.Add("includeTemplate", omitEmpty);
+            parameters.Add("status", status);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, BaseAddress, $"tags/slug/{slug}/related-tags", PolymarketPlatform.RateLimiter.GammaApi, 1, false);
             return await SendAsync<PolymarketRelatedTag[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -220,12 +215,12 @@ namespace Polymarket.Net.Clients.GammaApi
         #region Get Related Tags By Slug
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketTag[]>> GetTagsRelatedToTagByIdAsync(string id, bool? omitEmpty = null, TagStatus? status = null, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketTag[]>> GetTagsRelatedToTagByIdAsync(string id, bool? omitEmpty = null, TagStatus? status = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptionalBoolString("includeTemplate", omitEmpty);
-            parameters.AddOptionalEnum("status", status);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, $"tags/{id}/related-tags/tags", PolymarketPlatform.RateLimiter.GammaApi, 1, false);
+            var parameters = new Parameters(PolymarketPlatform._gammaParameterSerializationSettings);
+            parameters.Add("includeTemplate", omitEmpty);
+            parameters.Add("status", status);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, BaseAddress, $"tags/{id}/related-tags/tags", PolymarketPlatform.RateLimiter.GammaApi, 1, false);
             return await SendAsync<PolymarketTag[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -234,12 +229,12 @@ namespace Polymarket.Net.Clients.GammaApi
         #region Get Related Tags By Slug
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketTag[]>> GetTagsRelatedToTagBySlugAsync(string slug, bool? omitEmpty = null, TagStatus? status = null, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketTag[]>> GetTagsRelatedToTagBySlugAsync(string slug, bool? omitEmpty = null, TagStatus? status = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptionalBoolString("includeTemplate", omitEmpty);
-            parameters.AddOptionalEnum("status", status);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, $"tags/slug/{slug}/related-tags/tags", PolymarketPlatform.RateLimiter.GammaApi, 1, false);
+            var parameters = new Parameters(PolymarketPlatform._gammaParameterSerializationSettings);
+            parameters.Add("includeTemplate", omitEmpty);
+            parameters.Add("status", status);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, BaseAddress, $"tags/slug/{slug}/related-tags/tags", PolymarketPlatform.RateLimiter.GammaApi, 1, false);
             return await SendAsync<PolymarketTag[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -248,7 +243,7 @@ namespace Polymarket.Net.Clients.GammaApi
         #region Get Events
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketEventPage>> GetEventsKeysetPaginationAsync(
+        public async Task<HttpResult<PolymarketEventPage>> GetEventsKeysetPaginationAsync(
             long[]? ids = null,
             long[]? tagIds = null,
             long[]? excludeTagIds = null,
@@ -290,55 +285,55 @@ namespace Polymarket.Net.Clients.GammaApi
             bool? ascending = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("id", ids);
-            parameters.AddOptional("tag_id", tagIds);
-            parameters.AddOptional("exclude_tag_id", excludeTagIds);
-            parameters.AddOptional("slug", slugs);
-            parameters.AddOptional("tag_slug", tagSlug);
-            parameters.AddOptionalBoolString("related_tags", relatedTags);
-            parameters.AddOptionalBoolString("closed", closed);
-            parameters.AddOptionalBoolString("live", live);
-            parameters.AddOptionalBoolString("featured", featured);
-            parameters.AddOptionalBoolString("cyom", cyom);
-            parameters.AddOptional("title_search", titleSearch);
-            parameters.AddOptionalString("liquidity_min", liquidityMin);
-            parameters.AddOptionalString("liquidity_max", liquidityMax);
-            parameters.AddOptionalString("volume_min", volumeMin);
-            parameters.AddOptionalString("volume_max", volumeMax);
-            parameters.AddOptionalString("start_date_min", startDateMin);
-            parameters.AddOptionalString("start_date_max", startDateMax);
-            parameters.AddOptionalString("end_date_min", endDateMin);
-            parameters.AddOptionalString("end_date_max", endDateMax);
-            parameters.AddOptionalString("start_time_min", startTimeMin);
-            parameters.AddOptionalString("start_time_max", startTimeMax);
-            parameters.AddOptional("series_id", seriesIds);
-            parameters.AddOptional("game_id", gameIds);
-            parameters.AddOptionalString("event_date", eventDate);
-            parameters.AddOptional("event_week", eventWeek);
-            parameters.AddOptionalBoolString("featured_order", featuredOrder);
-            parameters.AddOptional("recurrence", recurrence);
-            parameters.AddOptional("created_by", createdBy);
-            parameters.AddOptional("parent_event_id", parentEventId);
-            parameters.AddOptionalBoolString("include_children", includeChildren);
-            parameters.AddOptional("partner_slug", partnerSlug);
-            parameters.AddOptionalBoolString("include_chat", includeChat);
-            parameters.AddOptionalBoolString("include_template", includeTemplate);
-            parameters.AddOptionalBoolString("include_best_lines", includeBestLines);
-            parameters.AddOptional("locale", locale);
-            parameters.AddOptional("after_cursor", afterCursor);
-            parameters.AddOptionalCommaSeparated("order", orderBy);
-            parameters.AddOptionalBoolString("ascending", ascending);
+            var parameters = new Parameters(PolymarketPlatform._gammaParameterSerializationSettings);
+            parameters.AddArray("id", ids);
+            parameters.AddArray("tag_id", tagIds);
+            parameters.AddArray("exclude_tag_id", excludeTagIds);
+            parameters.AddArray("slug", slugs);
+            parameters.Add("tag_slug", tagSlug);
+            parameters.Add("related_tags", relatedTags);
+            parameters.Add("closed", closed);
+            parameters.Add("live", live);
+            parameters.Add("featured", featured);
+            parameters.Add("cyom", cyom);
+            parameters.Add("title_search", titleSearch);
+            parameters.Add("liquidity_min", liquidityMin);
+            parameters.Add("liquidity_max", liquidityMax);
+            parameters.Add("volume_min", volumeMin);
+            parameters.Add("volume_max", volumeMax);
+            parameters.Add("start_date_min", startDateMin);
+            parameters.Add("start_date_max", startDateMax);
+            parameters.Add("end_date_min", endDateMin);
+            parameters.Add("end_date_max", endDateMax);
+            parameters.Add("start_time_min", startTimeMin);
+            parameters.Add("start_time_max", startTimeMax);
+            parameters.AddArray("series_id", seriesIds);
+            parameters.AddArray("game_id", gameIds);
+            parameters.Add("event_date", eventDate);
+            parameters.Add("event_week", eventWeek);
+            parameters.Add("featured_order", featuredOrder);
+            parameters.Add("recurrence", recurrence);
+            parameters.AddArray("created_by", createdBy);
+            parameters.Add("parent_event_id", parentEventId);
+            parameters.Add("include_children", includeChildren);
+            parameters.Add("partner_slug", partnerSlug);
+            parameters.Add("include_chat", includeChat);
+            parameters.Add("include_template", includeTemplate);
+            parameters.Add("include_best_lines", includeBestLines);
+            parameters.Add("locale", locale);
+            parameters.Add("after_cursor", afterCursor);
+            parameters.AddCommaSeparated("order", orderBy);
+            parameters.Add("ascending", ascending);
             parameters.Add("limit", limit ?? 20);
 
-            var request = _definitions.GetOrCreate(HttpMethod.Get, $"events/keyset", PolymarketPlatform.RateLimiter.GammaApi, 1, false,
+            var request = _definitions.GetOrCreate(HttpMethod.Get, BaseAddress, $"events/keyset", PolymarketPlatform.RateLimiter.GammaApi, 1, false,
                 limitGuard: new SingleLimitGuard(500, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             return await SendAsync<PolymarketEventPage>(request, parameters, ct).ConfigureAwait(false);
         }
 
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketEvent[]>> GetEventsAsync(
+        public async Task<HttpResult<PolymarketEvent[]>> GetEventsAsync(
             long[]? ids = null,
             long? tagId = null,
             long[]? excludeTagIds = null,
@@ -367,35 +362,35 @@ namespace Polymarket.Net.Clients.GammaApi
             bool? ascending = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("id", ids);
-            parameters.AddOptional("tag_id", tagId);
-            parameters.AddOptional("exclude_tag_id", excludeTagIds);
-            parameters.AddOptional("slug", slugs);
-            parameters.AddOptional("tag_slug", tagSlug);
-            parameters.AddOptionalBoolString("related_tags", relatedTags);
-            parameters.AddOptionalBoolString("active", active);
-            parameters.AddOptionalBoolString("archived", archived);
-            parameters.AddOptionalBoolString("featured", featured);
-            parameters.AddOptionalBoolString("cyom", cyom);
-            parameters.AddOptionalBoolString("include_chat", includeChat);
-            parameters.AddOptionalBoolString("include_template", includeTemplate);
-            parameters.AddOptionalBoolString("recurrence", recurrence);
-            parameters.AddOptionalBoolString("closed", closed);
-            parameters.AddOptionalString("liquidity_min", liquidityMin);
-            parameters.AddOptionalString("liquidity_max", liquidityMax);
-            parameters.AddOptionalString("volume_min", volumeMin);
-            parameters.AddOptionalString("volume_max", volumeMax);
-            parameters.AddOptionalString("start_date_min", startTimeMin);
-            parameters.AddOptionalString("start_date_max", startTimeMax);
-            parameters.AddOptionalString("end_date_min", endTimeMin);
-            parameters.AddOptionalString("end_date_max", endTimeMax);
+            var parameters = new Parameters(PolymarketPlatform._gammaParameterSerializationSettings);
+            parameters.AddArray("id", ids);
+            parameters.Add("tag_id", tagId);
+            parameters.AddArray("exclude_tag_id", excludeTagIds);
+            parameters.AddArray("slug", slugs);
+            parameters.Add("tag_slug", tagSlug);
+            parameters.Add("related_tags", relatedTags);
+            parameters.Add("active", active);
+            parameters.Add("archived", archived);
+            parameters.Add("featured", featured);
+            parameters.Add("cyom", cyom);
+            parameters.Add("include_chat", includeChat);
+            parameters.Add("include_template", includeTemplate);
+            parameters.Add("recurrence", recurrence);
+            parameters.Add("closed", closed);
+            parameters.Add("liquidity_min", liquidityMin);
+            parameters.Add("liquidity_max", liquidityMax);
+            parameters.Add("volume_min", volumeMin);
+            parameters.Add("volume_max", volumeMax);
+            parameters.Add("start_date_min", startTimeMin);
+            parameters.Add("start_date_max", startTimeMax);
+            parameters.Add("end_date_min", endTimeMin);
+            parameters.Add("end_date_max", endTimeMax);
 
-            parameters.AddOptionalCommaSeparated("order", orderBy);
-            parameters.AddOptionalBoolString("ascending", ascending);
+            parameters.AddCommaSeparated("order", orderBy);
+            parameters.Add("ascending", ascending);
             parameters.Add("limit", limit ?? 20);
             parameters.Add("offset", offset ?? 0);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, $"events", PolymarketPlatform.RateLimiter.GammaApi, 1, false,
+            var request = _definitions.GetOrCreate(HttpMethod.Get, BaseAddress, $"events", PolymarketPlatform.RateLimiter.GammaApi, 1, false,
                 limitGuard: new SingleLimitGuard(500, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             return await SendAsync<PolymarketEvent[]>(request, parameters, ct).ConfigureAwait(false);
         }
@@ -405,12 +400,12 @@ namespace Polymarket.Net.Clients.GammaApi
         #region Get Event By Id
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketEvent>> GetEventByIdAsync(string id, bool? includeChat = null, bool? includeTemplate = null, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketEvent>> GetEventByIdAsync(string id, bool? includeChat = null, bool? includeTemplate = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptionalBoolString("include_chat", includeChat);
-            parameters.AddOptionalBoolString("include_template", includeTemplate);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, $"events/" + id, PolymarketPlatform.RateLimiter.GammaApi, 1, false);
+            var parameters = new Parameters(PolymarketPlatform._gammaParameterSerializationSettings);
+            parameters.Add("include_chat", includeChat);
+            parameters.Add("include_template", includeTemplate);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, BaseAddress, $"events/" + id, PolymarketPlatform.RateLimiter.GammaApi, 1, false);
             return await SendAsync<PolymarketEvent>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -419,12 +414,12 @@ namespace Polymarket.Net.Clients.GammaApi
         #region Get Event By Slug
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketEvent>> GetEventBySlugAsync(string slug, bool? includeChat = null, bool? includeTemplate = null, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketEvent>> GetEventBySlugAsync(string slug, bool? includeChat = null, bool? includeTemplate = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptionalBoolString("include_chat", includeChat);
-            parameters.AddOptionalBoolString("include_template", includeTemplate);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, $"events/slug/" + slug, PolymarketPlatform.RateLimiter.GammaApi, 1, false);
+            var parameters = new Parameters(PolymarketPlatform._gammaParameterSerializationSettings);
+            parameters.Add("include_chat", includeChat);
+            parameters.Add("include_template", includeTemplate);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, BaseAddress, $"events/slug/" + slug, PolymarketPlatform.RateLimiter.GammaApi, 1, false);
             return await SendAsync<PolymarketEvent>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -433,10 +428,10 @@ namespace Polymarket.Net.Clients.GammaApi
         #region Get Event Tags
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketTag[]>> GetEventTagsAsync(string id, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketTag[]>> GetEventTagsAsync(string id, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            var request = _definitions.GetOrCreate(HttpMethod.Get, $"events/{id}/tags", PolymarketPlatform.RateLimiter.GammaApi, 1, false);
+            var parameters = new Parameters(PolymarketPlatform._gammaParameterSerializationSettings);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, BaseAddress, $"events/{id}/tags", PolymarketPlatform.RateLimiter.GammaApi, 1, false);
             return await SendAsync<PolymarketTag[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -445,7 +440,7 @@ namespace Polymarket.Net.Clients.GammaApi
         #region Get Markets
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketGammaMarket[]>> GetMarketsAsync(
+        public async Task<HttpResult<PolymarketGammaMarket[]>> GetMarketsAsync(
             long[]? ids = null,
             long? tagId = null,
             string[]? slugs = null,
@@ -475,36 +470,36 @@ namespace Polymarket.Net.Clients.GammaApi
             bool? ascending = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("id", ids);
-            parameters.AddOptional("tag_id", tagId);
-            parameters.AddOptional("slug", slugs);
-            parameters.AddOptional("clob_token_ids", clobTokenIds);
-            parameters.AddOptional("condition_ids", marketIds);
-            parameters.AddOptional("market_maker_address", marketMakerAddresses);
-            parameters.AddOptional("uma_resolution_status", umaResolutionStatus);
-            parameters.AddOptional("game_id", gameId);
-            parameters.AddOptional("sports_market_types", sportMarketTypes);
-            parameters.AddOptional("question_ids", questionIds);
-            parameters.AddOptionalBoolString("related_tags", relatedTags);
-            parameters.AddOptionalBoolString("cyom", cyom);
-            parameters.AddOptionalBoolString("include_tag", includeTag);
-            parameters.AddOptionalBoolString("closed", closed);
-            parameters.AddOptionalString("liquidity_min", liquidityMin);
-            parameters.AddOptionalString("liquidity_max", liquidityMax);
-            parameters.AddOptionalString("rewards_min", rewardsMin);
-            parameters.AddOptionalString("volume_min", volumeMin);
-            parameters.AddOptionalString("volume_max", volumeMax);
-            parameters.AddOptionalString("start_date_min", startTimeMin);
-            parameters.AddOptionalString("start_date_max", startTimeMax);
-            parameters.AddOptionalString("end_date_min", endTimeMin);
-            parameters.AddOptionalString("end_date_max", endTimeMax);
+            var parameters = new Parameters(PolymarketPlatform._gammaParameterSerializationSettings);
+            parameters.AddArray("id", ids);
+            parameters.Add("tag_id", tagId);
+            parameters.AddArray("slug", slugs);
+            parameters.AddArray("clob_token_ids", clobTokenIds);
+            parameters.AddArray("condition_ids", marketIds);
+            parameters.AddArray("market_maker_address", marketMakerAddresses);
+            parameters.Add("uma_resolution_status", umaResolutionStatus);
+            parameters.Add("game_id", gameId);
+            parameters.AddArray("sports_market_types", sportMarketTypes);
+            parameters.AddArray("question_ids", questionIds);
+            parameters.Add("related_tags", relatedTags);
+            parameters.Add("cyom", cyom);
+            parameters.Add("include_tag", includeTag);
+            parameters.Add("closed", closed);
+            parameters.Add("liquidity_min", liquidityMin);
+            parameters.Add("liquidity_max", liquidityMax);
+            parameters.Add("rewards_min", rewardsMin);
+            parameters.Add("volume_min", volumeMin);
+            parameters.Add("volume_max", volumeMax);
+            parameters.Add("start_date_min", startTimeMin);
+            parameters.Add("start_date_max", startTimeMax);
+            parameters.Add("end_date_min", endTimeMin);
+            parameters.Add("end_date_max", endTimeMax);
 
-            parameters.AddOptionalCommaSeparated("order", orderBy);
-            parameters.AddOptionalBoolString("ascending", ascending);
+            parameters.AddCommaSeparated("order", orderBy);
+            parameters.Add("ascending", ascending);
             parameters.Add("limit", limit ?? 20);
             parameters.Add("offset", offset ?? 0);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, $"markets", PolymarketPlatform.RateLimiter.GammaApi, 1, false,
+            var request = _definitions.GetOrCreate(HttpMethod.Get, BaseAddress, $"markets", PolymarketPlatform.RateLimiter.GammaApi, 1, false,
                 limitGuard: new SingleLimitGuard(300, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             return await SendAsync<PolymarketGammaMarket[]>(request, parameters, ct).ConfigureAwait(false);
         }
@@ -514,11 +509,11 @@ namespace Polymarket.Net.Clients.GammaApi
         #region Get Market By Id
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketGammaMarket>> GetMarketByIdAsync(string id, bool? includeTag = null, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketGammaMarket>> GetMarketByIdAsync(string id, bool? includeTag = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptionalBoolString("include_tag", includeTag);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, $"markets/" + id, PolymarketPlatform.RateLimiter.GammaApi, 1, false);
+            var parameters = new Parameters(PolymarketPlatform._gammaParameterSerializationSettings);
+            parameters.Add("include_tag", includeTag);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, BaseAddress, $"markets/" + id, PolymarketPlatform.RateLimiter.GammaApi, 1, false);
             return await SendAsync<PolymarketGammaMarket>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -527,11 +522,11 @@ namespace Polymarket.Net.Clients.GammaApi
         #region Get Market By Slug
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketGammaMarket>> GetMarketBySlugAsync(string slug, bool? includeTag = null, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketGammaMarket>> GetMarketBySlugAsync(string slug, bool? includeTag = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptionalBoolString("include_tag", includeTag);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, $"markets/slug/" + slug, PolymarketPlatform.RateLimiter.GammaApi, 1, false);
+            var parameters = new Parameters(PolymarketPlatform._gammaParameterSerializationSettings);
+            parameters.Add("include_tag", includeTag);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, BaseAddress, $"markets/slug/" + slug, PolymarketPlatform.RateLimiter.GammaApi, 1, false);
             return await SendAsync<PolymarketGammaMarket>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -540,10 +535,10 @@ namespace Polymarket.Net.Clients.GammaApi
         #region Get Market Tags
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketTag[]>> GetMarketTagsAsync(string id, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketTag[]>> GetMarketTagsAsync(string id, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            var request = _definitions.GetOrCreate(HttpMethod.Get, $"markets/{id}/tags", PolymarketPlatform.RateLimiter.GammaApi, 1, false);
+            var parameters = new Parameters(PolymarketPlatform._gammaParameterSerializationSettings);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, BaseAddress, $"markets/{id}/tags", PolymarketPlatform.RateLimiter.GammaApi, 1, false);
             return await SendAsync<PolymarketTag[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -552,7 +547,7 @@ namespace Polymarket.Net.Clients.GammaApi
         #region Get Series
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketSeries[]>> GetSeriesAsync(
+        public async Task<HttpResult<PolymarketSeries[]>> GetSeriesAsync(
             string[]? slugs = null,
             string[]? categoryIds = null,
             string[]? categoryLabels = null,
@@ -565,18 +560,18 @@ namespace Polymarket.Net.Clients.GammaApi
             bool? ascending = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("slug", slugs);
-            parameters.AddOptional("category_ids", categoryIds);
-            parameters.AddOptional("category_labels", categoryLabels);
-            parameters.AddOptionalBoolString("include_chat", includeChat);
-            parameters.AddOptionalBoolString("recurrence", recurrence);
-            parameters.AddOptionalBoolString("closed", closed);
-            parameters.AddOptionalCommaSeparated("order", orderBy);
-            parameters.AddOptionalBoolString("ascending", ascending);
+            var parameters = new Parameters(PolymarketPlatform._gammaParameterSerializationSettings);
+            parameters.AddArray("slug", slugs);
+            parameters.AddArray("category_ids", categoryIds);
+            parameters.AddArray("category_labels", categoryLabels);
+            parameters.Add("include_chat", includeChat);
+            parameters.Add("recurrence", recurrence);
+            parameters.Add("closed", closed);
+            parameters.AddCommaSeparated("order", orderBy);
+            parameters.Add("ascending", ascending);
             parameters.Add("limit", limit ?? 20);
             parameters.Add("offset", offset ?? 0);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, $"series", PolymarketPlatform.RateLimiter.GammaApi, 1, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, BaseAddress, $"series", PolymarketPlatform.RateLimiter.GammaApi, 1, false);
             return await SendAsync<PolymarketSeries[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -585,11 +580,11 @@ namespace Polymarket.Net.Clients.GammaApi
         #region Get Series By Id
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketSeries>> GetSeriesByIdAsync(string id, bool? includeChat = null, CancellationToken ct = default)
+        public async Task<HttpResult<PolymarketSeries>> GetSeriesByIdAsync(string id, bool? includeChat = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptionalBoolString("include_chat", includeChat);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, $"series/" + id, PolymarketPlatform.RateLimiter.GammaApi, 1, false);
+            var parameters = new Parameters(PolymarketPlatform._gammaParameterSerializationSettings);
+            parameters.Add("include_chat", includeChat);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, BaseAddress, $"series/" + id, PolymarketPlatform.RateLimiter.GammaApi, 1, false);
             return await SendAsync<PolymarketSeries>(request, parameters, ct).ConfigureAwait(false);
         }
 
@@ -598,7 +593,7 @@ namespace Polymarket.Net.Clients.GammaApi
         #region Search
 
         /// <inheritdoc />
-        public async Task<WebCallResult<PolymarketSearchResult>> SearchAsync(
+        public async Task<HttpResult<PolymarketSearchResult>> SearchAsync(
             string query,
             bool? cache = null,
             string? eventStatus = null,
@@ -615,22 +610,22 @@ namespace Polymarket.Net.Clients.GammaApi
             bool? optimized = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
+            var parameters = new Parameters(PolymarketPlatform._gammaParameterSerializationSettings);
             parameters.Add("q", query);
-            parameters.AddOptionalBoolString("cache", cache);
-            parameters.AddOptional("events_status", eventStatus);
-            parameters.AddOptional("limit_per_type", limitPerType);
-            parameters.AddOptional("page", page);
-            parameters.AddOptional("events_tag", eventTags);
-            parameters.AddOptional("keep_closed_markets", keepClosedMarkets);
-            parameters.AddOptional("sort", sort);
-            parameters.AddOptionalBoolString("ascending", ascending);
-            parameters.AddOptionalBoolString("search_tags", searchTags);
-            parameters.AddOptionalBoolString("search_profiles", searchProfiles);
-            parameters.AddOptional("recurrence", recurrence);
-            parameters.AddOptional("exclude_tag_id", excludeTagIds);
-            parameters.AddOptionalBoolString("optimized", optimized);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, $"public-search", PolymarketPlatform.RateLimiter.GammaApi, 1, false,
+            parameters.Add("cache", cache);
+            parameters.Add("events_status", eventStatus);
+            parameters.Add("limit_per_type", limitPerType);
+            parameters.Add("page", page);
+            parameters.AddArray("events_tag", eventTags);
+            parameters.Add("keep_closed_markets", keepClosedMarkets);
+            parameters.Add("sort", sort);
+            parameters.Add("ascending", ascending);
+            parameters.Add("search_tags", searchTags);
+            parameters.Add("search_profiles", searchProfiles);
+            parameters.Add("recurrence", recurrence);
+            parameters.AddArray("exclude_tag_id", excludeTagIds);
+            parameters.Add("optimized", optimized);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, BaseAddress, $"public-search", PolymarketPlatform.RateLimiter.GammaApi, 1, false,
                 limitGuard: new SingleLimitGuard(350, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding));
             return await SendAsync<PolymarketSearchResult>(request, parameters, ct).ConfigureAwait(false);
         }

--- a/Polymarket.Net/Clients/GammaApi/PolymarketRestClientGammaApi.cs
+++ b/Polymarket.Net/Clients/GammaApi/PolymarketRestClientGammaApi.cs
@@ -42,8 +42,8 @@ namespace Polymarket.Net.Clients.GammaApi
         #endregion
 
         #region constructor/destructor
-        internal PolymarketRestClientGammaApi(ILogger logger, HttpClient? httpClient, PolymarketRestOptions options)
-            : base(logger, PolymarketPlatform.Metadata.Id, httpClient, options.Environment.GammaRestClientAddress, options, options.GammaOptions)
+        internal PolymarketRestClientGammaApi(ILoggerFactory? loggerFactory, HttpClient? httpClient, PolymarketRestOptions options)
+            : base(loggerFactory, PolymarketPlatform.Metadata.Id, httpClient, options.Environment.GammaRestClientAddress, options, options.GammaOptions)
         {
             RequestBodyEmptyContent = "";
             ParameterPositions[HttpMethod.Delete] = HttpMethodParameterPosition.InBody;

--- a/Polymarket.Net/Clients/PolymarketRestClient.cs
+++ b/Polymarket.Net/Clients/PolymarketRestClient.cs
@@ -54,9 +54,9 @@ namespace Polymarket.Net.Clients
         {
             Initialize(options.Value);
             
-            ClobApi = AddApiClient(new PolymarketRestClientClobApi(_logger, httpClient, options.Value));
-            GammaApi = AddApiClient(new PolymarketRestClientGammaApi(_logger, httpClient, options.Value));
-            DataApi = AddApiClient(new PolymarketRestClientDataApi(_logger, httpClient, options.Value));
+            ClobApi = AddApiClient(new PolymarketRestClientClobApi(loggerFactory, httpClient, options.Value));
+            GammaApi = AddApiClient(new PolymarketRestClientGammaApi(loggerFactory, httpClient, options.Value));
+            DataApi = AddApiClient(new PolymarketRestClientDataApi(loggerFactory, httpClient, options.Value));
         }
 
         #endregion

--- a/Polymarket.Net/Clients/PolymarketSocketClient.cs
+++ b/Polymarket.Net/Clients/PolymarketSocketClient.cs
@@ -47,7 +47,7 @@ namespace Polymarket.Net.Clients
         {
             Initialize(options.Value);
                         
-            ClobApi = AddApiClient(new PolymarketSocketClientClobApi(_logger, options.Value));
+            ClobApi = AddApiClient(new PolymarketSocketClientClobApi(loggerFactory, options.Value));
         }
         #endregion
 

--- a/Polymarket.Net/Clients/PolymarketUserClientProvider.cs
+++ b/Polymarket.Net/Clients/PolymarketUserClientProvider.cs
@@ -6,20 +6,20 @@ using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Concurrent;
 using System.Net.Http;
+using CryptoExchange.Net.Clients;
 
 namespace Polymarket.Net.Clients
 {
     /// <inheritdoc />
-    public class PolymarketUserClientProvider : IPolymarketUserClientProvider
+    public class PolymarketUserClientProvider : UserClientProvider<
+        IPolymarketRestClient,
+        IPolymarketSocketClient,
+        PolymarketRestOptions,
+        PolymarketSocketOptions,
+        PolymarketCredentials,
+        PolymarketEnvironment
+        >, IPolymarketUserClientProvider
     {
-        private ConcurrentDictionary<string, IPolymarketRestClient> _restClients = new ConcurrentDictionary<string, IPolymarketRestClient>();
-        private ConcurrentDictionary<string, IPolymarketSocketClient> _socketClients = new ConcurrentDictionary<string, IPolymarketSocketClient>();
-        
-        private readonly IOptions<PolymarketRestOptions> _restOptions;
-        private readonly IOptions<PolymarketSocketOptions> _socketOptions;
-        private readonly HttpClient _httpClient;
-        private readonly ILoggerFactory? _loggerFactory;
-
         /// <summary>
         /// ctor
         /// </summary>
@@ -37,97 +37,18 @@ namespace Polymarket.Net.Clients
             ILoggerFactory? loggerFactory,
             IOptions<PolymarketRestOptions> restOptions,
             IOptions<PolymarketSocketOptions> socketOptions)
+            : base(httpClient, loggerFactory, restOptions, socketOptions)
         {
-            _httpClient = httpClient ?? new HttpClient();
-            _httpClient.Timeout = restOptions.Value.RequestTimeout;
-            _loggerFactory = loggerFactory;
-            _restOptions = restOptions;
-            _socketOptions = socketOptions;
         }
 
         /// <inheritdoc />
-        public void InitializeUserClient(string userIdentifier, PolymarketCredentials credentials, PolymarketEnvironment? environment = null)
-        {
-            CreateRestClient(userIdentifier, credentials, environment);
-            CreateSocketClient(userIdentifier, credentials, environment);
-        }
+        public override string ExchangeName => PolymarketPlatform.Metadata.Id;
 
         /// <inheritdoc />
-        public void ClearUserClients(string userIdentifier)
-        {
-            _restClients.TryRemove(userIdentifier, out _);
-            _socketClients.TryRemove(userIdentifier, out _);
-        }
-
+        protected override IPolymarketRestClient ConstructRestClient(HttpClient client, ILoggerFactory? loggerFactory, IOptions<PolymarketRestOptions> options)
+            => new PolymarketRestClient(client, loggerFactory, options);
         /// <inheritdoc />
-        public IPolymarketRestClient GetRestClient(string userIdentifier, PolymarketCredentials? credentials = null, PolymarketEnvironment? environment = null)
-        {
-            if (!_restClients.TryGetValue(userIdentifier, out var client) || client.Disposed)
-                client = CreateRestClient(userIdentifier, credentials, environment);
-
-            return client;
-        }
-
-        /// <inheritdoc />
-        public IPolymarketSocketClient GetSocketClient(string userIdentifier, PolymarketCredentials? credentials = null, PolymarketEnvironment? environment = null)
-        {
-            if (!_socketClients.TryGetValue(userIdentifier, out var client) || client.Disposed)
-                client = CreateSocketClient(userIdentifier, credentials, environment);
-
-            return client;
-        }
-
-        private IPolymarketRestClient CreateRestClient(string userIdentifier, PolymarketCredentials? credentials, PolymarketEnvironment? environment)
-        {
-            var clientRestOptions = SetRestEnvironment(environment);
-            var client = new PolymarketRestClient(_httpClient, _loggerFactory, clientRestOptions);
-            if (credentials != null)
-            {
-                client.SetApiCredentials(credentials);
-                _restClients[userIdentifier] = client;
-            }
-            return client;
-        }
-
-        private IPolymarketSocketClient CreateSocketClient(string userIdentifier, PolymarketCredentials? credentials, PolymarketEnvironment? environment)
-        {
-            var clientSocketOptions = SetSocketEnvironment(environment);
-            var client = new PolymarketSocketClient(clientSocketOptions!, _loggerFactory);
-            if (credentials != null)
-            {
-                client.SetApiCredentials(credentials);
-                _socketClients[userIdentifier] = client;
-            }
-            return client;
-        }
-
-        private IOptions<PolymarketRestOptions> SetRestEnvironment(PolymarketEnvironment? environment)
-        {
-            if (environment == null)
-                return _restOptions;
-
-            var newRestClientOptions = new PolymarketRestOptions();
-            var restOptions = _restOptions.Value.Set(newRestClientOptions);
-            newRestClientOptions.Environment = environment;
-            return Options.Create(newRestClientOptions);
-        }
-
-        private IOptions<PolymarketSocketOptions> SetSocketEnvironment(PolymarketEnvironment? environment)
-        {
-            if (environment == null)
-                return _socketOptions;
-
-            var newSocketClientOptions = new PolymarketSocketOptions();
-            var restOptions = _socketOptions.Value.Set(newSocketClientOptions);
-            newSocketClientOptions.Environment = environment;
-            return Options.Create(newSocketClientOptions);
-        }
-
-        private static T ApplyOptionsDelegate<T>(Action<T>? del) where T : new()
-        {
-            var opts = new T();
-            del?.Invoke(opts);
-            return opts;
-        }
+        protected override IPolymarketSocketClient ConstructSocketClient(ILoggerFactory? loggerFactory, IOptions<PolymarketSocketOptions> options)
+            => new PolymarketSocketClient(options, loggerFactory);
     }
 }

--- a/Polymarket.Net/Converters/PolymarketSourceGenerationContext.cs
+++ b/Polymarket.Net/Converters/PolymarketSourceGenerationContext.cs
@@ -46,7 +46,7 @@ namespace Polymarket.Net.Converters
     [JsonSerializable(typeof(PolymarketPage<PolymarketOrder>))]
     [JsonSerializable(typeof(PolymarketOrderResult))]
     [JsonSerializable(typeof(PolymarketOrderResult[]))]
-    [JsonSerializable(typeof(ParameterCollection))]
+    [JsonSerializable(typeof(Parameters))]
     [JsonSerializable(typeof(IDictionary<string, object>))]
     [JsonSerializable(typeof(string[]))]
     [JsonSerializable(typeof(PolymarketCancelResult))]
@@ -74,7 +74,7 @@ namespace Polymarket.Net.Converters
     [JsonSerializable(typeof(PolymarketTradeUpdate))]
     [JsonSerializable(typeof(PolymarketOrderUpdate))]
 
-    [JsonSerializable(typeof(ParameterCollection[]))]
+    [JsonSerializable(typeof(Parameters[]))]
     [JsonSerializable(typeof(string))]
     [JsonSerializable(typeof(int?))]
     [JsonSerializable(typeof(int))]

--- a/Polymarket.Net/Converters/PolymarketSourceGenerationContext.cs
+++ b/Polymarket.Net/Converters/PolymarketSourceGenerationContext.cs
@@ -47,6 +47,7 @@ namespace Polymarket.Net.Converters
     [JsonSerializable(typeof(PolymarketOrderResult))]
     [JsonSerializable(typeof(PolymarketOrderResult[]))]
     [JsonSerializable(typeof(Parameters))]
+    [JsonSerializable(typeof(Parameters[]))]
     [JsonSerializable(typeof(IDictionary<string, object>))]
     [JsonSerializable(typeof(string[]))]
     [JsonSerializable(typeof(PolymarketCancelResult))]

--- a/Polymarket.Net/Interfaces/Clients/ClobApi/IPolymarketRestClientClobApiAccount.cs
+++ b/Polymarket.Net/Interfaces/Clients/ClobApi/IPolymarketRestClientClobApiAccount.cs
@@ -24,7 +24,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// </summary>
         /// <param name="nonce">["<c>nonce</c>"] Nonce, different nonces can be used to create different credentials</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketCreds>> CreateApiCredentialsAsync(long? nonce = null, CancellationToken ct = default);
+        Task<HttpResult<PolymarketCreds>> CreateApiCredentialsAsync(long? nonce = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get previously created API credentials for the provided API credentials private key
@@ -37,7 +37,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// </summary>
         /// <param name="nonce">["<c>nonce</c>"] Nonce</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketCreds>> GetApiCredentialsAsync(long? nonce = null, CancellationToken ct = default);
+        Task<HttpResult<PolymarketCreds>> GetApiCredentialsAsync(long? nonce = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get previously created API credentials, or create new credentials if no credentials are created yet
@@ -51,38 +51,38 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// </summary>
         /// <param name="nonce">["<c>nonce</c>"] Nonce</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketCreds>> GetOrCreateApiCredentialsAsync(long? nonce = null, CancellationToken ct = default);
+        Task<HttpResult<PolymarketCreds>> GetOrCreateApiCredentialsAsync(long? nonce = null, CancellationToken ct = default);
 
         /// <summary>
         /// List API keys for the provided API credentials private key
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketApiKeys>> GetApiKeysAsync(CancellationToken ct = default);
+        Task<HttpResult<PolymarketApiKeys>> GetApiKeysAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Delete an API key
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult> DeleteApiKeyAsync(CancellationToken ct = default);
+        Task<HttpResult> DeleteApiKeyAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get closed only mode
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketClosedOnlyMode>> GetClosedOnlyModeAsync(CancellationToken ct = default);
+        Task<HttpResult<PolymarketClosedOnlyMode>> GetClosedOnlyModeAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get notifications
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketNotification[]>> GetNotificationsAsync(CancellationToken ct = default);
+        Task<HttpResult<PolymarketNotification[]>> GetNotificationsAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Drop notifications
         /// </summary>
         /// <param name="ids">["<c>ids</c>"] Ids to drop</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketNotification[]>> DropNotificationsAsync(IEnumerable<string> ids, CancellationToken ct = default);
+        Task<HttpResult<PolymarketNotification[]>> DropNotificationsAsync(IEnumerable<string> ids, CancellationToken ct = default);
 
         /// <summary>
         /// Get balance allowance
@@ -96,7 +96,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// <param name="assetType">["<c>asset_type</c>"] Asset type</param>
         /// <param name="tokenId">["<c>token_id</c>"] Token id, required for AssetType.Conditional</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketBalanceAllowance>> GetBalanceAllowanceAsync(AssetType assetType, string? tokenId = null, CancellationToken ct = default);
+        Task<HttpResult<PolymarketBalanceAllowance>> GetBalanceAllowanceAsync(AssetType assetType, string? tokenId = null, CancellationToken ct = default);
 
         /// <summary>
         /// Update balance allowance
@@ -104,7 +104,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// <param name="assetType">["<c>asset_type</c>"] Asset type</param>
         /// <param name="tokenId">["<c>token_id</c>"] Token id</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult> UpdateBalanceAllowanceAsync(AssetType assetType, string? tokenId = null, CancellationToken ct = default);
+        Task<HttpResult> UpdateBalanceAllowanceAsync(AssetType assetType, string? tokenId = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get trades for builder
@@ -117,7 +117,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// <param name="endTime">["<c>before</c>"] Filter by end time</param>
         /// <param name="cursor">["<c>next_cursor</c>"] Next page cursor</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketPage<PolymarketBuilderTrade>>> GetBuilderTradesAsync(
+        Task<HttpResult<PolymarketPage<PolymarketBuilderTrade>>> GetBuilderTradesAsync(
             string builderCode,
             string? tradeId = null,
             string? marketId = null,

--- a/Polymarket.Net/Interfaces/Clients/ClobApi/IPolymarketRestClientClobApiExchangeData.cs
+++ b/Polymarket.Net/Interfaces/Clients/ClobApi/IPolymarketRestClientClobApiExchangeData.cs
@@ -24,7 +24,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// </summary>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<DateTime>> GetServerTimeAsync(CancellationToken ct = default);
+        Task<HttpResult<DateTime>> GetServerTimeAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get geographical restrictions for calling client
@@ -36,7 +36,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// </para>
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketGeoRestriction>> GetGeographicRestrictionsAsync(CancellationToken ct = default);
+        Task<HttpResult<PolymarketGeoRestriction>> GetGeographicRestrictionsAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get sampling simplified markets
@@ -49,7 +49,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// </summary>
         /// <param name="cursor">Pagination cursor</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketPage<PolymarketMarket>>> GetSamplingSimplifiedMarketsAsync(string? cursor = null, CancellationToken ct = default);
+        Task<HttpResult<PolymarketPage<PolymarketMarket>>> GetSamplingSimplifiedMarketsAsync(string? cursor = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get sampling markets
@@ -62,7 +62,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// </summary>
         /// <param name="cursor">Pagination cursor</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketPage<PolymarketMarketDetails>>> GetSamplingMarketsAsync(string? cursor = null, CancellationToken ct = default);
+        Task<HttpResult<PolymarketPage<PolymarketMarketDetails>>> GetSamplingMarketsAsync(string? cursor = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get simplified markets
@@ -75,7 +75,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// </summary>
         /// <param name="cursor">Pagination cursor</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketPage<PolymarketMarket>>> GetSimplifiedMarketsAsync(string? cursor = null, CancellationToken ct = default);
+        Task<HttpResult<PolymarketPage<PolymarketMarket>>> GetSimplifiedMarketsAsync(string? cursor = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get markets
@@ -88,7 +88,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// </summary>
         /// <param name="cursor">Pagination cursor</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketPage<PolymarketMarketDetails>>> GetMarketsAsync(string? cursor = null, CancellationToken ct = default);
+        Task<HttpResult<PolymarketPage<PolymarketMarketDetails>>> GetMarketsAsync(string? cursor = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get market by id
@@ -101,7 +101,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// </summary>
         /// <param name="id">Id</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketMarketDetails>> GetMarketAsync(string id, CancellationToken ct = default);
+        Task<HttpResult<PolymarketMarketDetails>> GetMarketAsync(string id, CancellationToken ct = default);
 
         /// <summary>
         /// Get price for a token
@@ -115,7 +115,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// <param name="tokenId">["<c>token_id</c>"] Token id</param>
         /// <param name="side">["<c>side</c>"] Side</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketPrice>> GetPriceAsync(string tokenId, OrderSide side, CancellationToken ct = default);
+        Task<HttpResult<PolymarketPrice>> GetPriceAsync(string tokenId, OrderSide side, CancellationToken ct = default);
 
         /// <summary>
         /// Get buy/sell prices for all markets
@@ -128,7 +128,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// </summary>
         /// <param name="tokens">Tokens to retrieve prices for</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<Dictionary<string, PolymarketBuySellPrice>>> GetPricesAsync(Dictionary<string, OrderSide> tokens, CancellationToken ct = default);
+        Task<HttpResult<Dictionary<string, PolymarketBuySellPrice>>> GetPricesAsync(Dictionary<string, OrderSide> tokens, CancellationToken ct = default);
 
         /// <summary>
         /// Get the midpoint price for a token
@@ -141,7 +141,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// </summary>
         /// <param name="tokenId">["<c>token_id</c>"] The token id</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketMidPrice>> GetMidpointPriceAsync(string tokenId, CancellationToken ct = default);
+        Task<HttpResult<PolymarketMidPrice>> GetMidpointPriceAsync(string tokenId, CancellationToken ct = default);
 
         /// <summary>
         /// Get mid point prices for tokens
@@ -154,7 +154,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// </summary>
         /// <param name="tokenIds">["<c>token_id</c>"] Tokens to request</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<Dictionary<string, decimal>>> GetMidpointPricesAsync(IEnumerable<string> tokenIds, CancellationToken ct = default);
+        Task<HttpResult<Dictionary<string, decimal>>> GetMidpointPricesAsync(IEnumerable<string> tokenIds, CancellationToken ct = default);
 
         /// <summary>
         /// Get price history for a token
@@ -171,7 +171,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// <param name="interval">["<c>interval</c>"] Interval</param>
         /// <param name="fidelity">["<c>fidelity</c>"] Fidelity in minutes</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketPriceHistory[]>> GetPriceHistoryAsync(string market, DateTime? startTime = null, DateTime? endTime = null, DataInterval? interval = null, int? fidelity = null, CancellationToken ct = default);
+        Task<HttpResult<PolymarketPriceHistory[]>> GetPriceHistoryAsync(string market, DateTime? startTime = null, DateTime? endTime = null, DataInterval? interval = null, int? fidelity = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get bid/ask spread for a a token
@@ -184,7 +184,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// </summary>
         /// <param name="tokenId">["<c>token_id</c>"] Token id</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketSpread>> GetBidAskSpreadsAsync(string tokenId, CancellationToken ct = default);
+        Task<HttpResult<PolymarketSpread>> GetBidAskSpreadsAsync(string tokenId, CancellationToken ct = default);
 
         /// <summary>
         /// Get bid/ask spread for specified token ids
@@ -197,7 +197,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// </summary>
         /// <param name="tokenIds">["<c>token_id</c>"] Token ids</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<Dictionary<string, decimal>>> GetBidAskSpreadsAsync(IEnumerable<string> tokenIds, CancellationToken ct = default);
+        Task<HttpResult<Dictionary<string, decimal>>> GetBidAskSpreadsAsync(IEnumerable<string> tokenIds, CancellationToken ct = default);
 
         /// <summary>
         /// Get order book info for a token
@@ -210,7 +210,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// </summary>
         /// <param name="tokenId">["<c>token_id</c>"] The token id</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketOrderBook>> GetOrderBookAsync(string tokenId, CancellationToken ct = default);
+        Task<HttpResult<PolymarketOrderBook>> GetOrderBookAsync(string tokenId, CancellationToken ct = default);
 
         /// <summary>
         /// Get order book info for multiple tokens
@@ -223,7 +223,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// </summary>
         /// <param name="tokenIds">["<c>token_id</c>"] The token ids</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketOrderBook[]>> GetOrderBooksAsync(IEnumerable<string> tokenIds, CancellationToken ct = default);
+        Task<HttpResult<PolymarketOrderBook[]>> GetOrderBooksAsync(IEnumerable<string> tokenIds, CancellationToken ct = default);
 
         /// <summary>
         /// Get tick size for a token
@@ -236,7 +236,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// </summary>
         /// <param name="tokenId">["<c>token_id</c>"] The token id</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketTickSize>> GetTickSizeAsync(string tokenId, CancellationToken ct = default);
+        Task<HttpResult<PolymarketTickSize>> GetTickSizeAsync(string tokenId, CancellationToken ct = default);
 
         /// <summary>
         /// Get negative risk for a token
@@ -247,7 +247,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// </summary>
         /// <param name="tokenId">["<c>token_id</c>"] The token id</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketNegRisk>> GetNegativeRiskAsyncAsync(string tokenId, CancellationToken ct = default);
+        Task<HttpResult<PolymarketNegRisk>> GetNegativeRiskAsyncAsync(string tokenId, CancellationToken ct = default);
 
         /// <summary>
         /// Get fee rate in basis points
@@ -260,7 +260,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// </summary>
         /// <param name="tokenId">["<c>token_id</c>"] The token id</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketFeeRateBps>> GetFeeRateBpsAsync(string tokenId, CancellationToken ct = default);
+        Task<HttpResult<PolymarketFeeRateBps>> GetFeeRateBpsAsync(string tokenId, CancellationToken ct = default);
 
         /// <summary>
         /// Get last trade price for a token
@@ -273,7 +273,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// </summary>
         /// <param name="tokenId">["<c>token_id</c>"] The token id</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketTradePrice>> GetLastTradePriceAsync(string tokenId, CancellationToken ct = default);
+        Task<HttpResult<PolymarketTradePrice>> GetLastTradePriceAsync(string tokenId, CancellationToken ct = default);
 
         /// <summary>
         /// Get last trade price for tokens
@@ -286,7 +286,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// </summary>
         /// <param name="tokenIds">["<c>token_id</c>"] The token ids</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketTradePrice[]>> GetLastTradePricesAsync(IEnumerable<string> tokenIds, CancellationToken ct = default);
+        Task<HttpResult<PolymarketTradePrice[]>> GetLastTradePricesAsync(IEnumerable<string> tokenIds, CancellationToken ct = default);
 
         /// <summary>
         /// Get info on a market
@@ -299,7 +299,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// </summary>
         /// <param name="marketId">["<c>condition_id</c>"] Id of the market</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketMarketInfo>> GetMarketInfoAsync(string marketId, CancellationToken ct = default);
+        Task<HttpResult<PolymarketMarketInfo>> GetMarketInfoAsync(string marketId, CancellationToken ct = default);
 
 
     }

--- a/Polymarket.Net/Interfaces/Clients/ClobApi/IPolymarketRestClientClobApiTrading.cs
+++ b/Polymarket.Net/Interfaces/Clients/ClobApi/IPolymarketRestClientClobApiTrading.cs
@@ -87,6 +87,8 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// <param name="clientOrderId">["<c>order.salt</c>"] Client order id</param>
         /// <param name="expiration">["<c>order.expiration</c>"] Expiration time</param>
         /// <param name="quantityType">Type of quantity for an order, either in shares (default) or in value (USD). Value is only available for market buy orders</param>
+        /// <param name="tickQuantity">Tick quantity, can be provided together with negative risk to bypass token info retrieval for limit orders</param>
+        /// <param name="negativeRisk">If negative risk token, can be provided together with tickQuantity to bypass token info retrieval for limit orders</param>
         /// <param name="ct">Cancellation token</param>
         Task<HttpResult<PolymarketOrderResult>> PlaceOrderAsync(
             string tokenId,
@@ -99,6 +101,8 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
             long? clientOrderId = null,
             DateTime? expiration = null,
             QuantityType? quantityType = null,
+            decimal? tickQuantity = null,
+            bool? negativeRisk = null,
             CancellationToken ct = default);
 
         /// <summary>

--- a/Polymarket.Net/Interfaces/Clients/ClobApi/IPolymarketRestClientClobApiTrading.cs
+++ b/Polymarket.Net/Interfaces/Clients/ClobApi/IPolymarketRestClientClobApiTrading.cs
@@ -27,7 +27,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// <param name="tokenId">Asset/token id</param>
         /// <param name="cursor">Next page cursor</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketPage<PolymarketOrder>>> GetOpenOrdersAsync(string? orderId = null, string? marketId = null, string? tokenId = null, string? cursor = null, CancellationToken ct = default);
+        Task<HttpResult<PolymarketPage<PolymarketOrder>>> GetOpenOrdersAsync(string? orderId = null, string? marketId = null, string? tokenId = null, string? cursor = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get an order by id
@@ -40,7 +40,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// </summary>
         /// <param name="orderId">["<c>order_id</c>"] Order id</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketOrder>> GetOrderAsync(string orderId, CancellationToken ct = default);
+        Task<HttpResult<PolymarketOrder>> GetOrderAsync(string orderId, CancellationToken ct = default);
 
         /// <summary>
         /// Check if an order is eligible or scoring for Rewards purposes
@@ -53,7 +53,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// </summary>
         /// <param name="orderId">Order id</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketOrderScoring>> GetOrderRewardScoringAsync(string orderId, CancellationToken ct = default);
+        Task<HttpResult<PolymarketOrderScoring>> GetOrderRewardScoringAsync(string orderId, CancellationToken ct = default);
 
         /// <summary>
         /// Check if orders are eligible or scoring for Rewards purposes
@@ -66,7 +66,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// </summary>
         /// <param name="orderIds">Order ids</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<Dictionary<string, bool>>> GetOrdersRewardScoringAsync(IEnumerable<string> orderIds, CancellationToken ct = default);
+        Task<HttpResult<Dictionary<string, bool>>> GetOrdersRewardScoringAsync(IEnumerable<string> orderIds, CancellationToken ct = default);
 
         /// <summary>
         /// Place a new order
@@ -88,7 +88,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// <param name="expiration">["<c>order.expiration</c>"] Expiration time</param>
         /// <param name="quantityType">Type of quantity for an order, either in shares (default) or in value (USD). Value is only available for market buy orders</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketOrderResult>> PlaceOrderAsync(
+        Task<HttpResult<PolymarketOrderResult>> PlaceOrderAsync(
             string tokenId,
             OrderSide side,
             OrderType orderType,
@@ -112,7 +112,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// </summary>
         /// <param name="requests">Order requests</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<CallResult<PolymarketOrderResult>[]>> PlaceMultipleOrdersAsync(IEnumerable<PolymarketOrderRequest> requests, CancellationToken ct = default);
+        Task<HttpResult<CallResult<PolymarketOrderResult>[]>> PlaceMultipleOrdersAsync(IEnumerable<PolymarketOrderRequest> requests, CancellationToken ct = default);
 
         /// <summary>
         /// Cancel an order
@@ -125,7 +125,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// </summary>
         /// <param name="orderId">["<c>orderID</c>"] Order id</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketCancelResult>> CancelOrderAsync(string orderId, CancellationToken ct = default);
+        Task<HttpResult<PolymarketCancelResult>> CancelOrderAsync(string orderId, CancellationToken ct = default);
         /// <summary>
         /// Cancel multiple orders
         /// <para>
@@ -137,7 +137,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// </summary>
         /// <param name="orderIds">Ids of orders to cancel</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketCancelResult>> CancelOrdersAsync(IEnumerable<string> orderIds, CancellationToken ct = default);
+        Task<HttpResult<PolymarketCancelResult>> CancelOrdersAsync(IEnumerable<string> orderIds, CancellationToken ct = default);
         /// <summary>
         /// Cancel all orders for a specific market
         /// <para>
@@ -150,7 +150,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// <param name="marketId">["<c>market</c>"] The condition/market id</param>
         /// <param name="tokenId">["<c>asset_id</c>"] Asset/token id</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketCancelResult>> CancelOrdersOnMarketAsync(string? marketId = null, string? tokenId = null, CancellationToken ct = default);
+        Task<HttpResult<PolymarketCancelResult>> CancelOrdersOnMarketAsync(string? marketId = null, string? tokenId = null, CancellationToken ct = default);
         /// <summary>
         /// Cancel all open orders
         /// <para>
@@ -161,7 +161,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// </para>
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketCancelResult>> CancelAllOrdersAsync(CancellationToken ct = default);
+        Task<HttpResult<PolymarketCancelResult>> CancelAllOrdersAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get trades matching the filters
@@ -180,7 +180,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// <param name="endTime">["<c>before</c>"] Filter by end time</param>
         /// <param name="cursor">["<c>next_cursor</c>"] Next page cursor</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketPage<PolymarketTrade>>> GetUserTradesAsync(
+        Task<HttpResult<PolymarketPage<PolymarketTrade>>> GetUserTradesAsync(
             string? tradeId = null,
             string? makerAddress = null,
             string? marketId = null,
@@ -200,6 +200,6 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// </para>
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult> PostOrderHeartbeatAsync(CancellationToken ct = default);
+        Task<HttpResult> PostOrderHeartbeatAsync(CancellationToken ct = default);
     }
 }

--- a/Polymarket.Net/Interfaces/Clients/ClobApi/IPolymarketSocketClientClobApi.cs
+++ b/Polymarket.Net/Interfaces/Clients/ClobApi/IPolymarketSocketClientClobApi.cs
@@ -27,7 +27,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// <param name="onMarketResolvedUpdate">Market resolved update handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToPlatformUpdatesAsync(
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToPlatformUpdatesAsync(
             Action<DataEvent<PolymarketNewMarketUpdate>>? onNewMarketUpdate = null,
             Action<DataEvent<PolymarketMarketResolvedUpdate>>? onMarketResolvedUpdate = null,
             CancellationToken ct = default);
@@ -49,7 +49,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// <param name="onBestBidAskUpdate">Best bid/ask update handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToTokenUpdatesAsync(
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToTokenUpdatesAsync(
             IEnumerable<string> tokenIds, 
             Action<DataEvent<PolymarketPriceChangeUpdate>>? onPriceChangeUpdate = null,
             Action<DataEvent<PolymarketBookUpdate>>? onBookUpdate = null,
@@ -71,7 +71,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// <param name="onTradeUpdate">User trade update handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToUserUpdatesAsync(
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToUserUpdatesAsync(
             Action<DataEvent<PolymarketOrderUpdate>>? onOrderUpdate = null,
             Action<DataEvent<PolymarketTradeUpdate>>? onTradeUpdate = null,
             CancellationToken ct = default);
@@ -88,7 +88,7 @@ namespace Polymarket.Net.Interfaces.Clients.ClobApi
         /// <param name="onSportsUpdate">Sport match update handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToSportsUpdatesAsync(
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToSportsUpdatesAsync(
             Action<DataEvent<PolymarketSportsUpdate>>? onSportsUpdate = null,
             CancellationToken ct = default);
     }

--- a/Polymarket.Net/Interfaces/Clients/DataApi/IPolymarketRestClientDataApi.cs
+++ b/Polymarket.Net/Interfaces/Clients/DataApi/IPolymarketRestClientDataApi.cs
@@ -24,6 +24,6 @@ namespace Polymarket.Net.Interfaces.Clients.DataApi
         /// <param name="user">["<c>user</c>"] By user</param>
         /// <param name="ct"></param>
         /// <returns></returns>
-        Task<WebCallResult<PolymarketPosition[]>> GetPositionsAsync(string user, CancellationToken ct = default);
+        Task<HttpResult<PolymarketPosition[]>> GetPositionsAsync(string user, CancellationToken ct = default);
     }
 }

--- a/Polymarket.Net/Interfaces/Clients/GammaApi/IPolymarketRestClientGammaApi.cs
+++ b/Polymarket.Net/Interfaces/Clients/GammaApi/IPolymarketRestClientGammaApi.cs
@@ -37,7 +37,7 @@ namespace Polymarket.Net.Interfaces.Clients.GammaApi
         /// <param name="orderBy">["<c>order</c>"] Order by fields</param>
         /// <param name="ascending">["<c>ascending</c>"] Ascending order</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketSportsTeam[]>> GetSportTeamsAsync(
+        Task<HttpResult<PolymarketSportsTeam[]>> GetSportTeamsAsync(
             IEnumerable<string>? league = null,
             IEnumerable<string>? name = null,
             IEnumerable<string>? abbreviation = null,
@@ -57,7 +57,7 @@ namespace Polymarket.Net.Interfaces.Clients.GammaApi
         /// </para>
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketSport[]>> GetSportsAsync(CancellationToken ct = default);
+        Task<HttpResult<PolymarketSport[]>> GetSportsAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get valid sport market types
@@ -69,7 +69,7 @@ namespace Polymarket.Net.Interfaces.Clients.GammaApi
         /// </para>
         /// </summary>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<string[]>> GetSportMarketTypesAsync(CancellationToken ct = default);
+        Task<HttpResult<string[]>> GetSportMarketTypesAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get tags
@@ -87,7 +87,7 @@ namespace Polymarket.Net.Interfaces.Clients.GammaApi
         /// <param name="orderBy">["<c>order</c>"] Order by fields</param>
         /// <param name="ascending">["<c>ascending</c>"] Ascending order</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketTag[]>> GetTagsAsync(
+        Task<HttpResult<PolymarketTag[]>> GetTagsAsync(
             bool? includeTemplate = null,
             bool? isCarousel = null,
             int? limit = null,
@@ -108,7 +108,7 @@ namespace Polymarket.Net.Interfaces.Clients.GammaApi
         /// <param name="id">Id</param>
         /// <param name="includeTemplate">["<c>includeTemplate</c>"] Include template</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketTag>> GetTagByIdAsync(string id, bool? includeTemplate = null, CancellationToken ct = default);
+        Task<HttpResult<PolymarketTag>> GetTagByIdAsync(string id, bool? includeTemplate = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get tag by slug
@@ -122,7 +122,7 @@ namespace Polymarket.Net.Interfaces.Clients.GammaApi
         /// <param name="slug">Slug</param>
         /// <param name="includeTemplate">["<c>includeTemplate</c>"] Include template</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketTag>> GetTagBySlugAsync(string slug, bool? includeTemplate = null, CancellationToken ct = default);
+        Task<HttpResult<PolymarketTag>> GetTagBySlugAsync(string slug, bool? includeTemplate = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get related tags for a tag
@@ -137,7 +137,7 @@ namespace Polymarket.Net.Interfaces.Clients.GammaApi
         /// <param name="omitEmpty">["<c>includeTemplate</c>"] Omit empty</param>
         /// <param name="status">["<c>status</c>"] Filter by status</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketRelatedTag[]>> GetRelatedTagsByIdAsync(string id, bool? omitEmpty = null, TagStatus? status = null, CancellationToken ct = default);
+        Task<HttpResult<PolymarketRelatedTag[]>> GetRelatedTagsByIdAsync(string id, bool? omitEmpty = null, TagStatus? status = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get related tags for a tag
@@ -152,7 +152,7 @@ namespace Polymarket.Net.Interfaces.Clients.GammaApi
         /// <param name="omitEmpty">["<c>includeTemplate</c>"] Omit empty</param>
         /// <param name="status">["<c>status</c>"] Filter by status</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketRelatedTag[]>> GetRelatedTagsBySlugAsync(string slug, bool? omitEmpty = null, TagStatus? status = null, CancellationToken ct = default);
+        Task<HttpResult<PolymarketRelatedTag[]>> GetRelatedTagsBySlugAsync(string slug, bool? omitEmpty = null, TagStatus? status = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get tags related to a tag by id
@@ -167,7 +167,7 @@ namespace Polymarket.Net.Interfaces.Clients.GammaApi
         /// <param name="omitEmpty">["<c>includeTemplate</c>"] Omit empty</param>
         /// <param name="status">["<c>status</c>"] Filter by status</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketTag[]>> GetTagsRelatedToTagByIdAsync(string id, bool? omitEmpty = null, TagStatus? status = null, CancellationToken ct = default);
+        Task<HttpResult<PolymarketTag[]>> GetTagsRelatedToTagByIdAsync(string id, bool? omitEmpty = null, TagStatus? status = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get tags related to a tag by slug
@@ -182,7 +182,7 @@ namespace Polymarket.Net.Interfaces.Clients.GammaApi
         /// <param name="omitEmpty">["<c>includeTemplate</c>"] Omit empty</param>
         /// <param name="status">["<c>status</c>"] Filter by status</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketTag[]>> GetTagsRelatedToTagBySlugAsync(string slug, bool? omitEmpty = null, TagStatus? status = null, CancellationToken ct = default);
+        Task<HttpResult<PolymarketTag[]>> GetTagsRelatedToTagBySlugAsync(string slug, bool? omitEmpty = null, TagStatus? status = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get events
@@ -233,7 +233,7 @@ namespace Polymarket.Net.Interfaces.Clients.GammaApi
         /// <param name="orderBy">["<c>order</c>"] Order by fields</param>
         /// <param name="ascending">["<c>ascending</c>"] Ascending order</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketEventPage>> GetEventsKeysetPaginationAsync(
+        Task<HttpResult<PolymarketEventPage>> GetEventsKeysetPaginationAsync(
             long[]? ids = null,
             long[]? tagIds = null,
             long[]? excludeTagIds = null,
@@ -311,7 +311,7 @@ namespace Polymarket.Net.Interfaces.Clients.GammaApi
         /// <param name="orderBy">["<c>order</c>"] Order by fields</param>
         /// <param name="ascending">["<c>ascending</c>"] Ascending order</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketEvent[]>> GetEventsAsync(
+        Task<HttpResult<PolymarketEvent[]>> GetEventsAsync(
             long[]? ids = null,
             long? tagId = null,
             long[]? excludeTagIds = null,
@@ -353,7 +353,7 @@ namespace Polymarket.Net.Interfaces.Clients.GammaApi
         /// <param name="includeChat">["<c>include_chat</c>"] Include chat</param>
         /// <param name="includeTemplate">["<c>include_template</c>"] Include template</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketEvent>> GetEventByIdAsync(string id, bool? includeChat = null, bool? includeTemplate = null, CancellationToken ct = default);
+        Task<HttpResult<PolymarketEvent>> GetEventByIdAsync(string id, bool? includeChat = null, bool? includeTemplate = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get event by slug
@@ -368,7 +368,7 @@ namespace Polymarket.Net.Interfaces.Clients.GammaApi
         /// <param name="includeChat">["<c>include_chat</c>"] Include chat</param>
         /// <param name="includeTemplate">["<c>include_template</c>"] Include template</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketEvent>> GetEventBySlugAsync(string slug, bool? includeChat = null, bool? includeTemplate = null, CancellationToken ct = default);
+        Task<HttpResult<PolymarketEvent>> GetEventBySlugAsync(string slug, bool? includeChat = null, bool? includeTemplate = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get event tags
@@ -381,7 +381,7 @@ namespace Polymarket.Net.Interfaces.Clients.GammaApi
         /// </summary>
         /// <param name="id">Id</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketTag[]>> GetEventTagsAsync(string id, CancellationToken ct = default);
+        Task<HttpResult<PolymarketTag[]>> GetEventTagsAsync(string id, CancellationToken ct = default);
 
         /// <summary>
         /// Get events
@@ -420,7 +420,7 @@ namespace Polymarket.Net.Interfaces.Clients.GammaApi
         /// <param name="orderBy">["<c>order</c>"] Order by fields</param>
         /// <param name="ascending">["<c>ascending</c>"] Ascending order</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketGammaMarket[]>> GetMarketsAsync(
+        Task<HttpResult<PolymarketGammaMarket[]>> GetMarketsAsync(
             long[]? ids = null,
             long? tagId = null,
             string[]? slugs = null,
@@ -462,7 +462,7 @@ namespace Polymarket.Net.Interfaces.Clients.GammaApi
         /// <param name="id">Id</param>
         /// <param name="includeTag">["<c>include_tag</c>"] Include tag</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketGammaMarket>> GetMarketByIdAsync(string id, bool? includeTag = null, CancellationToken ct = default);
+        Task<HttpResult<PolymarketGammaMarket>> GetMarketByIdAsync(string id, bool? includeTag = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get market by slug
@@ -476,7 +476,7 @@ namespace Polymarket.Net.Interfaces.Clients.GammaApi
         /// <param name="slug">Slug</param>
         /// <param name="includeTag">["<c>include_tag</c>"] Include tag</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketGammaMarket>> GetMarketBySlugAsync(string slug, bool? includeTag = null, CancellationToken ct = default);
+        Task<HttpResult<PolymarketGammaMarket>> GetMarketBySlugAsync(string slug, bool? includeTag = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get market tags
@@ -489,7 +489,7 @@ namespace Polymarket.Net.Interfaces.Clients.GammaApi
         /// </summary>
         /// <param name="id">Id</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketTag[]>> GetMarketTagsAsync(string id, CancellationToken ct = default);
+        Task<HttpResult<PolymarketTag[]>> GetMarketTagsAsync(string id, CancellationToken ct = default);
 
         /// <summary>
         /// Get series
@@ -511,7 +511,7 @@ namespace Polymarket.Net.Interfaces.Clients.GammaApi
         /// <param name="orderBy">["<c>order</c>"] Order by fields</param>
         /// <param name="ascending">["<c>ascending</c>"] Ascending order</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketSeries[]>> GetSeriesAsync(
+        Task<HttpResult<PolymarketSeries[]>> GetSeriesAsync(
             string[]? slugs = null,
             string[]? categoryIds = null,
             string[]? categoryLabels = null,
@@ -536,7 +536,7 @@ namespace Polymarket.Net.Interfaces.Clients.GammaApi
         /// <param name="id">Id</param>
         /// <param name="includeChat">["<c>include_chat</c>"] Whether to include chat</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketSeries>> GetSeriesByIdAsync(string id, bool? includeChat = null, CancellationToken ct = default);
+        Task<HttpResult<PolymarketSeries>> GetSeriesByIdAsync(string id, bool? includeChat = null, CancellationToken ct = default);
 
         /// <summary>
         /// Public search
@@ -562,7 +562,7 @@ namespace Polymarket.Net.Interfaces.Clients.GammaApi
         /// <param name="excludeTagIds">["<c>exclude_tag_id</c>"] Exclude tag ids</param>
         /// <param name="optimized">["<c>optimized</c>"] Optimized</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<PolymarketSearchResult>> SearchAsync(
+        Task<HttpResult<PolymarketSearchResult>> SearchAsync(
             string query,
             bool? cache = null,
             string? eventStatus = null,

--- a/Polymarket.Net/Objects/Models/PolymarketOrderRequest.cs
+++ b/Polymarket.Net/Objects/Models/PolymarketOrderRequest.cs
@@ -53,5 +53,15 @@ namespace Polymarket.Net.Objects.Models
         /// Type of quantity for an order, either in shares (default) or in value (USD). Value is only available for market buy orders
         /// </summary>
         public QuantityType? QuantityType { get; set; }
+
+        /// <summary>
+        /// Tick quantity, can be provided together with negative risk to bypass token info retrieval for limit orders
+        /// </summary>
+        public decimal? TickQuantity { get; set; }
+
+        /// <summary>
+        /// If negative risk token, can be provided together with tickQuantity to bypass token info retrieval for limit orders
+        /// </summary>
+        public bool? NegativeRisk { get; set; }
     }
 }

--- a/Polymarket.Net/Objects/Sockets/PolymarketInitialQuery.cs
+++ b/Polymarket.Net/Objects/Sockets/PolymarketInitialQuery.cs
@@ -24,7 +24,7 @@ namespace Polymarket.Net.Objects.Sockets
         {
             ExpectsResponse = false;
 
-            MessageRouter = MessageRouter.CreateWithoutHandler<T>("");
+            MessageRouter = MessageRouter.CreateVoid<T>("");
         }
     }
 }

--- a/Polymarket.Net/Objects/Sockets/PolymarketPingQuery.cs
+++ b/Polymarket.Net/Objects/Sockets/PolymarketPingQuery.cs
@@ -11,7 +11,7 @@ namespace Polymarket.Net.Objects.Sockets
         public PolymarketPingQuery() : base("ping", false, 0)
         {
             RequestTimeout = TimeSpan.FromSeconds(5);
-            MessageRouter = MessageRouter.CreateWithoutHandler<string>("pong");
+            MessageRouter = MessageRouter.CreateVoid<string>("pong");
         }
     }
 }

--- a/Polymarket.Net/Objects/Sockets/PolymarketQuery.cs
+++ b/Polymarket.Net/Objects/Sockets/PolymarketQuery.cs
@@ -19,7 +19,7 @@ namespace Polymarket.Net.Objects.Sockets
         {
             ExpectsResponse = false;
 
-            MessageRouter = MessageRouter.CreateWithoutHandler<T>("");
+            MessageRouter = MessageRouter.CreateVoid<T>("");
         }
     }
 }

--- a/Polymarket.Net/Objects/Sockets/Subscriptions/PolymarketGeneralSubscription.cs
+++ b/Polymarket.Net/Objects/Sockets/Subscriptions/PolymarketGeneralSubscription.cs
@@ -34,8 +34,8 @@ namespace Polymarket.Net.Objects.Sockets.Subscriptions
             _marketResolvedUpdate = marketResolvedUpdate;
 
             MessageRouter = MessageRouter.Create([
-                MessageRoute<PolymarketNewMarketUpdate>.CreateWithoutTopicFilter("new_market", DoHandleMessage),
-                MessageRoute<PolymarketMarketResolvedUpdate>.CreateWithoutTopicFilter("market_resolved", DoHandleMessage)
+                MessageRoute.CreateForEvent<PolymarketNewMarketUpdate>("new_market", DoHandleMessage),
+                MessageRoute.CreateForEvent<PolymarketMarketResolvedUpdate>("market_resolved", DoHandleMessage)
                 ]);
         }
 
@@ -58,7 +58,7 @@ namespace Polymarket.Net.Objects.Sockets.Subscriptions
                         .WithStreamId(message.EventType)
                         //.WithSymbol(data.Symbol)
                         .WithDataTimestamp(message.Timestamp, _client.GetTimeOffset()));
-            return new CallResult(null);
+            return CallResult.Ok();
         }
 
         /// <inheritdoc />
@@ -71,7 +71,7 @@ namespace Polymarket.Net.Objects.Sockets.Subscriptions
                         .WithStreamId(message.EventType)
                         //.WithSymbol(data.Symbol)
                         .WithDataTimestamp(message.Timestamp, _client.GetTimeOffset()));
-            return new CallResult(null);
+            return CallResult.Ok();
         }
     }
 }

--- a/Polymarket.Net/Objects/Sockets/Subscriptions/PolymarketGeneralSystemSubscription.cs
+++ b/Polymarket.Net/Objects/Sockets/Subscriptions/PolymarketGeneralSystemSubscription.cs
@@ -19,8 +19,8 @@ namespace Polymarket.Net.Objects.Sockets.Subscriptions
         public PolymarketGeneralSystemSubscription(ILogger logger) : base(logger, false)
         {
             MessageRouter = MessageRouter.Create([
-                MessageRoute<PolymarketNewMarketUpdate>.CreateWithoutTopicFilter("new_market", DoHandleMessage),
-                MessageRoute<PolymarketNewMarketUpdate>.CreateWithoutTopicFilter("market_resolved", DoHandleMessage)
+                MessageRoute.CreateForEvent<PolymarketNewMarketUpdate>("new_market", DoHandleMessage),
+                MessageRoute.CreateForEvent<PolymarketNewMarketUpdate>("market_resolved", DoHandleMessage)
                 ]);
         }
 
@@ -33,13 +33,13 @@ namespace Polymarket.Net.Objects.Sockets.Subscriptions
         /// <inheritdoc />
         public CallResult DoHandleMessage(SocketConnection connection, DateTime receiveTime, string? originalData, PolymarketNewMarketUpdate message)
         {
-            return CallResult.SuccessResult;
+            return CallResult.Ok();
         }
 
         /// <inheritdoc />
         public CallResult DoHandleMessage(SocketConnection connection, DateTime receiveTime, string? originalData, PolymarketMarketResolvedUpdate message)
         {
-            return CallResult.SuccessResult;
+            return CallResult.Ok();
         }
     }
 }

--- a/Polymarket.Net/Objects/Sockets/Subscriptions/PolymarketSportSubscription.cs
+++ b/Polymarket.Net/Objects/Sockets/Subscriptions/PolymarketSportSubscription.cs
@@ -25,7 +25,7 @@ namespace Polymarket.Net.Objects.Sockets.Subscriptions
         {
             _updateHandler = updateHandler;
 
-            MessageRouter = MessageRouter.CreateWithoutTopicFilter<PolymarketSportsUpdate>("sports", DoHandleMessage);
+            MessageRouter = MessageRouter.CreateForEvent<PolymarketSportsUpdate>("sports", DoHandleMessage);
         }
 
         /// <inheritdoc />
@@ -41,7 +41,7 @@ namespace Polymarket.Net.Objects.Sockets.Subscriptions
             _updateHandler?.Invoke(new DataEvent<PolymarketSportsUpdate>(PolymarketPlatform.Metadata.Id, message, receiveTime, originalData)
                         .WithUpdateType(SocketUpdateType.Update)
                         .WithStreamId("sports"));
-            return CallResult.SuccessResult;
+            return CallResult.Ok();
         }
 
     }

--- a/Polymarket.Net/Objects/Sockets/Subscriptions/PolymarketTokenSubscription.cs
+++ b/Polymarket.Net/Objects/Sockets/Subscriptions/PolymarketTokenSubscription.cs
@@ -51,14 +51,14 @@ namespace Polymarket.Net.Objects.Sockets.Subscriptions
 
             var routes = new List<MessageRoute>();
 
-            routes.Add(MessageRoute<PolymarketPriceChangeUpdate>.CreateWithoutTopicFilter("price_change", DoHandleMessage));
+            routes.Add(MessageRoute.CreateForEvent<PolymarketPriceChangeUpdate>("price_change", DoHandleMessage));
             foreach(var item in tokenIds)
             {
-                routes.Add(MessageRoute<PolymarketBookUpdate>.CreateWithTopicFilter("book", item, DoHandleMessage));
-                routes.Add(MessageRoute<PolymarketBookUpdate[]>.CreateWithTopicFilter("book_snapshot", item, DoHandleMessage));
-                routes.Add(MessageRoute<PolymarketLastTradePriceUpdate>.CreateWithTopicFilter("last_trade_price", item, DoHandleMessage));
-                routes.Add(MessageRoute<PolymarketTickSizeUpdate>.CreateWithTopicFilter("tick_size_change", item, DoHandleMessage));
-                routes.Add(MessageRoute<PolymarketBestBidAskUpdate>.CreateWithTopicFilter("best_bid_ask", item, DoHandleMessage));
+                routes.Add(MessageRoute.CreateForEvent<PolymarketBookUpdate>("book", item, DoHandleMessage));
+                routes.Add(MessageRoute.CreateForEvent<PolymarketBookUpdate[]>("book_snapshot", item, DoHandleMessage));
+                routes.Add(MessageRoute.CreateForEvent<PolymarketLastTradePriceUpdate>("last_trade_price", item, DoHandleMessage));
+                routes.Add(MessageRoute.CreateForEvent<PolymarketTickSizeUpdate>("tick_size_change", item, DoHandleMessage));
+                routes.Add(MessageRoute.CreateForEvent<PolymarketBestBidAskUpdate>("best_bid_ask", item, DoHandleMessage));
             }
 
             MessageRouter = MessageRouter.Create(routes.ToArray());
@@ -83,7 +83,7 @@ namespace Polymarket.Net.Objects.Sockets.Subscriptions
 
             var updates = message.PriceChanges.Where(x => _tokenIds.Contains(x.TokenId)).ToArray();
             if (updates.Length == 0)
-                return CallResult.SuccessResult;
+                return CallResult.Ok();
 
             var update = message with { PriceChanges = updates };
             _priceChangeHandler?.Invoke(new DataEvent<PolymarketPriceChangeUpdate>(PolymarketPlatform.Metadata.Id, update, receiveTime, originalData)
@@ -91,7 +91,7 @@ namespace Polymarket.Net.Objects.Sockets.Subscriptions
                         .WithStreamId(message.EventType)
                         //.WithSymbol(data.Symbol)
                         .WithDataTimestamp(message.Timestamp, _client.GetTimeOffset()));
-            return CallResult.SuccessResult;
+            return CallResult.Ok();
         }
 
         /// <inheritdoc />
@@ -104,7 +104,7 @@ namespace Polymarket.Net.Objects.Sockets.Subscriptions
                         .WithStreamId(message.EventType)
                         //.WithSymbol(data.Symbol)
                         .WithDataTimestamp(message.Timestamp, _client.GetTimeOffset()));
-            return CallResult.SuccessResult;
+            return CallResult.Ok();
         }
 
         /// <inheritdoc />
@@ -117,7 +117,7 @@ namespace Polymarket.Net.Objects.Sockets.Subscriptions
                         .WithStreamId(message.EventType)
                         //.WithSymbol(data.Symbol)
                         .WithDataTimestamp(message.Timestamp, _client.GetTimeOffset()));
-            return CallResult.SuccessResult;
+            return CallResult.Ok();
         }
 
         /// <inheritdoc />
@@ -135,7 +135,7 @@ namespace Polymarket.Net.Objects.Sockets.Subscriptions
                             .WithDataTimestamp(message.Timestamp, _client.GetTimeOffset()));
             }
 
-            return CallResult.SuccessResult;
+            return CallResult.Ok();
         }
 
         /// <inheritdoc />
@@ -148,7 +148,7 @@ namespace Polymarket.Net.Objects.Sockets.Subscriptions
                         .WithStreamId(message.EventType)
                         //.WithSymbol(data.Symbol)
                         .WithDataTimestamp(message.Timestamp, _client.GetTimeOffset()));
-            return CallResult.SuccessResult;
+            return CallResult.Ok();
         }
 
         /// <inheritdoc />
@@ -161,7 +161,7 @@ namespace Polymarket.Net.Objects.Sockets.Subscriptions
                         .WithStreamId(message.EventType)
                         //.WithSymbol(data.Symbol)
                         .WithDataTimestamp(message.Timestamp, _client.GetTimeOffset()));
-            return CallResult.SuccessResult;
+            return CallResult.Ok();
         }
     }
 }

--- a/Polymarket.Net/Objects/Sockets/Subscriptions/PolymarketUserSubscription.cs
+++ b/Polymarket.Net/Objects/Sockets/Subscriptions/PolymarketUserSubscription.cs
@@ -34,8 +34,8 @@ namespace Polymarket.Net.Objects.Sockets.Subscriptions
             _tradeUpdate = tradeUpdate;
 
             MessageRouter = MessageRouter.Create([
-                MessageRoute<PolymarketTradeUpdate>.CreateWithoutTopicFilter("trade", DoHandleMessage),
-                MessageRoute<PolymarketOrderUpdate>.CreateWithoutTopicFilter("order", DoHandleMessage)
+                MessageRoute.CreateForEvent<PolymarketTradeUpdate>("trade", DoHandleMessage),
+                MessageRoute.CreateForEvent<PolymarketOrderUpdate>("order", DoHandleMessage)
                 ]);
         }
 
@@ -55,7 +55,7 @@ namespace Polymarket.Net.Objects.Sockets.Subscriptions
                         .WithStreamId(message.EventType)
                         //.WithSymbol(data.Symbol)
                         .WithDataTimestamp(message.Timestamp, _client.GetTimeOffset()));
-            return new CallResult(null);
+            return CallResult.Ok();
         }
 
         /// <inheritdoc />
@@ -68,7 +68,7 @@ namespace Polymarket.Net.Objects.Sockets.Subscriptions
                         .WithStreamId(message.EventType)
                         //.WithSymbol(data.Symbol)
                         .WithDataTimestamp(message.Timestamp, _client.GetTimeOffset()));
-            return new CallResult(null);
+            return CallResult.Ok();
         }
     }
 }

--- a/Polymarket.Net/Polymarket.Net.csproj
+++ b/Polymarket.Net/Polymarket.Net.csproj
@@ -53,13 +53,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="CryptoExchange.Net" Version="12.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Secp256k1.Net" Version="2.0.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>

--- a/Polymarket.Net/Polymarket.Net.csproj
+++ b/Polymarket.Net/Polymarket.Net.csproj
@@ -53,11 +53,13 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="CryptoExchange.Net" Version="11.2.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Secp256k1.Net" Version="2.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>

--- a/Polymarket.Net/PolymarketAuthenticationProvider.cs
+++ b/Polymarket.Net/PolymarketAuthenticationProvider.cs
@@ -115,7 +115,7 @@ namespace Polymarket.Net
             var signData = timestamp + requestConfig.RequestDefinition.Method.ToString() + requestConfig.RequestDefinition.Path;
             if (requestConfig.RequestDefinition.Method == HttpMethod.Post || requestConfig.RequestDefinition.Method == HttpMethod.Delete)
             {
-                var body = (requestConfig.BodyParameters == null || requestConfig.BodyParameters.Count == 0) ? string.Empty : GetSerializedBody(_serializer, requestConfig.BodyParameters);
+                var body = (requestConfig.BodyParameters == null || requestConfig.BodyParameters.Empty) ? string.Empty : GetSerializedBody(_serializer, requestConfig.BodyParameters);
                 signData += body;
                 requestConfig.SetBodyContent(body);
             }

--- a/Polymarket.Net/PolymarketAuthenticationProvider.cs
+++ b/Polymarket.Net/PolymarketAuthenticationProvider.cs
@@ -58,11 +58,11 @@ namespace Polymarket.Net
 
         public override void ProcessRequest(RestApiClient apiClient, RestRequestConfiguration requestConfig)
         {
-            if (!requestConfig.Authenticated)
+            if (!requestConfig.RequestDefinition.Authenticated)
                 return;
 
-            if ((requestConfig.Path.Equals("/auth/api-key") && requestConfig.Method == HttpMethod.Post)
-                || (requestConfig.Path.Equals("/auth/derive-api-key") && requestConfig.Method == HttpMethod.Get))
+            if ((requestConfig.RequestDefinition.Path.Equals("/auth/api-key") && requestConfig.RequestDefinition.Method == HttpMethod.Post)
+                || (requestConfig.RequestDefinition.Path.Equals("/auth/derive-api-key") && requestConfig.RequestDefinition.Method == HttpMethod.Get))
             {
                 // L1 authentication
                 SignL1Custom(requestConfig, ((PolymarketRestOptions)apiClient.ClientOptions).Environment.ChainId);
@@ -112,8 +112,8 @@ namespace Polymarket.Net
             requestConfig.Headers.Add("POLY_PASSPHRASE", ApiCredentials.L2.Pass!);
             requestConfig.Headers.Add("POLY_TIMESTAMP", timestamp.Value.ToString());
 
-            var signData = timestamp + requestConfig.Method.ToString() + requestConfig.Path;
-            if (requestConfig.Method == HttpMethod.Post || requestConfig.Method == HttpMethod.Delete)
+            var signData = timestamp + requestConfig.RequestDefinition.Method.ToString() + requestConfig.RequestDefinition.Path;
+            if (requestConfig.RequestDefinition.Method == HttpMethod.Post || requestConfig.RequestDefinition.Method == HttpMethod.Delete)
             {
                 var body = (requestConfig.BodyParameters == null || requestConfig.BodyParameters.Count == 0) ? string.Empty : GetSerializedBody(_serializer, requestConfig.BodyParameters);
                 signData += body;
@@ -127,7 +127,7 @@ namespace Polymarket.Net
             requestConfig.Headers.Add("POLY_SIGNATURE", signature.Replace('+', '-').Replace('/', '_'));
         }
 
-        public string GetOrderSignature(ParameterCollection parameters, uint chainId, bool negativeRisk)
+        public string GetOrderSignature(Parameters parameters, uint chainId, bool negativeRisk)
         {
             var signType = (int)parameters["signatureType"];
             if (signType == (int)SignType.Poly1271)
@@ -196,7 +196,7 @@ namespace Polymarket.Net
             return result;
         }
 
-        private string GetContract(ParameterCollection order, uint chainId, bool negativeRisk)
+        private string GetContract(Parameters order, uint chainId, bool negativeRisk)
         {
             if (chainId == 137)            
                 return negativeRisk ? PolymarketContractsConfig.PolygonNegRiskConfig.Exchange : PolymarketContractsConfig.PolygonConfig.Exchange;            
@@ -206,7 +206,7 @@ namespace Polymarket.Net
                 throw new InvalidOperationException("Unknown chainId: " + chainId);
         }
 
-        private CeTypedDataRaw GetTypeDataRawCustom(ParameterCollection order, uint chainId, bool negativeRisk)
+        private CeTypedDataRaw GetTypeDataRawCustom(Parameters order, uint chainId, bool negativeRisk)
         {
             return new CeTypedDataRaw
             {

--- a/Polymarket.Net/PolymarketPlatform.cs
+++ b/Polymarket.Net/PolymarketPlatform.cs
@@ -50,7 +50,7 @@ namespace Polymarket.Net
         /// <summary>
         /// Rate limiter configuration for the Polymarket API
         /// </summary>
-        public static PolymarketRateLimiters RateLimiter { get; } = new PolymarketRateLimiters();
+        public static PolymarketRateLimiters RateLimiter { get; set; } = new PolymarketRateLimiters();
     }
 
     /// <summary>
@@ -68,13 +68,19 @@ namespace Polymarket.Net
         public event Action<RateLimitUpdateEvent> RateLimitUpdated;
 
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        internal PolymarketRateLimiters()
+        /// <summary>
+        /// ctor
+        /// </summary>
+        public PolymarketRateLimiters()
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         {
             Initialize();
         }
 
-        private void Initialize()
+        /// <summary>
+        /// Initialize the rate limits
+        /// </summary>
+        protected virtual void Initialize()
         {
             ClobApi = new RateLimitGate("Clob")
                 .AddGuard(new RateLimitGuard(RateLimitGuard.PerHost, new LimitItemTypeFilter(RateLimitItemType.Request), 9000, TimeSpan.FromSeconds(10), RateLimitWindowType.Sliding)); // 9000 requests per 10 seconds

--- a/Polymarket.Net/PolymarketPlatform.cs
+++ b/Polymarket.Net/PolymarketPlatform.cs
@@ -44,7 +44,8 @@ namespace Polymarket.Net
                 "https://www.polymarket.com",
                 ["https://docs.polymarket.com/api-reference"],
                 PlatformType.PredictionMarket,
-                CentralizationType.Decentralized
+                CentralizationType.Decentralized,
+                PolymarketEnvironment.All
                 );
 
         /// <summary>

--- a/Polymarket.Net/PolymarketPlatform.cs
+++ b/Polymarket.Net/PolymarketPlatform.cs
@@ -19,7 +19,21 @@ namespace Polymarket.Net
     public static class PolymarketPlatform
     {
         internal static JsonSerializerOptions _serializerContext = SerializerOptions.WithConverters(JsonSerializerContextCache.GetOrCreate<PolymarketSourceGenerationContext>());
-        
+        internal static ParameterSerializationSettings _parameterSerializationSettings = new ParameterSerializationSettings
+        {
+            Sort = false,
+            Decimal = DecimalSerialization.String,
+            DateTimes = DateTimeSerialization.MillisecondsString
+        };
+        internal static ParameterSerializationSettings _gammaParameterSerializationSettings = new ParameterSerializationSettings
+        {
+            Sort = false,
+            Decimal = DecimalSerialization.String,
+            DateTimes = DateTimeSerialization.MillisecondsString,
+            Bool = BoolSerialization.String,
+            Array = ArrayParametersSerialization.MultipleValues
+        };
+
         /// <summary>
         /// Platform metadata
         /// </summary>

--- a/Polymarket.Net/SymbolOrderBooks/PolymarketClobSymbolOrderBook.cs
+++ b/Polymarket.Net/SymbolOrderBooks/PolymarketClobSymbolOrderBook.cs
@@ -62,22 +62,22 @@ namespace Polymarket.Net.SymbolOrderBooks
         protected override async Task<CallResult<UpdateSubscription>> DoStartAsync(CancellationToken ct)
         {
             var result = await _socketClient.ClobApi.SubscribeToTokenUpdatesAsync([Symbol], onBookUpdate: ProcessUpdate).ConfigureAwait(false);
-            if (!result)
-                return result;
+            if (!result.Success)
+                return CallResult.Fail<UpdateSubscription>(result.Error);
 
             if (ct.IsCancellationRequested)
             {
                 await result.Data.CloseAsync().ConfigureAwait(false);
-                return result.AsError<UpdateSubscription>(new CancellationRequestedError());
+                return CallResult.Fail<UpdateSubscription>(new CancellationRequestedError());
             }
 
             Status = OrderBookStatus.Syncing;
 
             var setResult = await WaitForSetOrderBookAsync(_initialDataTimeout, ct).ConfigureAwait(false);
-            if (!setResult)
+            if (!setResult.Success)
                 await result.Data.CloseAsync().ConfigureAwait(false);
 
-            return setResult ? result : new CallResult<UpdateSubscription>(setResult.Error!);
+            return setResult.Success ? CallResult.Ok(result.Data) : CallResult.Fail<UpdateSubscription>(setResult.Error!);
         }
 
         private void ProcessUpdate(DataEvent<PolymarketBookUpdate> @event)
@@ -91,7 +91,7 @@ namespace Polymarket.Net.SymbolOrderBooks
         }
 
         /// <inheritdoc />
-        protected override async Task<CallResult<bool>> DoResyncAsync(CancellationToken ct)
+        protected override async Task<CallResult> DoResyncAsync(CancellationToken ct)
         {
             return await WaitForSetOrderBookAsync(_initialDataTimeout, ct).ConfigureAwait(false);
         }

--- a/Polymarket.Net/Utils/PolymarketUtils.cs
+++ b/Polymarket.Net/Utils/PolymarketUtils.cs
@@ -28,27 +28,27 @@ namespace Polymarket.Net.Utils
             {
                 var envName = client.ClientOptions.Environment.Name;
                 if (envName.Equals("UnitTest", StringComparison.Ordinal))
-                    return new CallResult<PolymarketOrderBook>(new PolymarketOrderBook { TickQuantity = 0.1m });
+                    return CallResult<PolymarketOrderBook>.Ok(new PolymarketOrderBook { TickQuantity = 0.1m });
 
                 if (_tokenInfos.TryGetValue(envName, out var envTokens) && envTokens.TryGetValue(tokenId, out var cachedTokenInfo)
                     && DateTime.UtcNow - cachedTokenInfo.LastUpdateTime < TimeSpan.FromSeconds(2))
                 {
                     // Have this token data and it's up to date
-                    return new CallResult<PolymarketOrderBook>(cachedTokenInfo.Book);
+                    return CallResult<PolymarketOrderBook>.Ok(cachedTokenInfo.Book);
                 }
 
                 var result = await UpdateTokenInfoAsync(envName, [tokenId], client).ConfigureAwait(false);
-                if (!result)
-                    return result.As<PolymarketOrderBook>(default);
+                if (!result.Success)
+                    return CallResult.Fail<PolymarketOrderBook>(result.Error);
 
                 var token = result.Data.FirstOrDefault(x => x.TokenId == tokenId);
                 if (token == null)
                 {
-                    return new CallResult<PolymarketOrderBook>(
+                    return CallResult.Fail<PolymarketOrderBook>(
                         new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, $"Token {tokenId} not found")));
                 }
 
-                return new CallResult<PolymarketOrderBook>(token);
+                return CallResult.Ok(token);
             }
             finally
             {
@@ -66,7 +66,7 @@ namespace Polymarket.Net.Utils
             {
                 var envName = client.ClientOptions.Environment.Name;
                 if (envName.Equals("UnitTest", StringComparison.Ordinal))
-                    return new CallResult<PolymarketOrderBook[]>(tokenIds.Select(x => new PolymarketOrderBook { TickQuantity = 0.1m, TokenId = x }).ToArray());
+                    return CallResult.Ok(tokenIds.Select(x => new PolymarketOrderBook { TickQuantity = 0.1m, TokenId = x }).ToArray());
 
                 // Get tokens that are not in cache or outdated
                 var toRequest = new List<string>();
@@ -81,11 +81,11 @@ namespace Polymarket.Net.Utils
 
                 // Update the tokens that are not in cache or outdated
                 var result = await UpdateTokenInfoAsync(envName, toRequest, client).ConfigureAwait(false);
-                if (!result)
+                if (!result.Success)
                     return result;
 
                 // All tokens should now be in cache, return them
-                return new CallResult<PolymarketOrderBook[]>(tokenIds.Select(x => _tokenInfos[envName][x].Book).ToArray());
+                return CallResult.Ok(tokenIds.Select(x => _tokenInfos[envName][x].Book).ToArray());
             }
             finally
             {
@@ -96,15 +96,15 @@ namespace Polymarket.Net.Utils
         private static async Task<CallResult<PolymarketOrderBook[]>> UpdateTokenInfoAsync(string envName, IEnumerable<string> tokenIds, IPolymarketRestClientClobApi client)
         {
             var tokenInfo = await client.ExchangeData.GetOrderBooksAsync(tokenIds).ConfigureAwait(false);
-            if (!tokenInfo)
-                return tokenInfo;
+            if (!tokenInfo.Success)
+                return CallResult.Fail<PolymarketOrderBook[]>(tokenInfo.Error);
 
             if (!_tokenInfos.ContainsKey(envName))
                 _tokenInfos[envName] = new Dictionary<string, PolymarketTokenCache>();
 
             foreach(var result in tokenInfo.Data)
                 _tokenInfos[envName][result.TokenId] = new PolymarketTokenCache(DateTime.UtcNow, result);
-            return tokenInfo;
+            return CallResult.Ok(tokenInfo.Data);
         }
 
         private class PolymarketTokenCache

--- a/docs/ai-api-map.md
+++ b/docs/ai-api-map.md
@@ -173,5 +173,5 @@ Use this file to route common user intents to the correct Polymarket.Net client 
 | `.SharedClient` | Not exposed by current Polymarket.Net interfaces |
 | `.Data` without `.Success` check | Check `.Success` first |
 | L1-only credentials for order placement | Add or derive L2 credentials |
-| `PolymarketOrderResult.Success` only | Check `WebCallResult.Success` first, then order result success |
+| `PolymarketOrderResult.Success` only | Check `HttpResult.Success` first, then order result success |
 | Manual socket lifecycle without storing subscription | Store `UpdateSubscription` and unsubscribe |

--- a/docs/ai-api-map.md
+++ b/docs/ai-api-map.md
@@ -140,6 +140,8 @@ Use this file to route common user intents to the correct Polymarket.Net client 
 | Subscribe sports updates | `socketClient.ClobApi.SubscribeToSportsUpdatesAsync(onSportsUpdate)` |
 | Unsubscribe from socket stream | `socketClient.UnsubscribeAsync(subscription.Data)` |
 
+WebSocket subscription methods return `WebSocketResult<UpdateSubscription>`.
+
 ## Local Order Book And User Client Provider
 
 | User intent | Polymarket.Net member |
@@ -155,9 +157,9 @@ Use this file to route common user intents to the correct Polymarket.Net client 
 
 | Situation | Pattern |
 |---|---|
-| REST success check | `if (!result.Success) { Console.WriteLine(result.Error); return; }` |
-| Socket subscription success check | `if (!sub.Success) { Console.WriteLine(sub.Error); return; }` |
-| Read REST data | Read `result.Data` only after `result.Success` |
+| REST success check | REST methods return `HttpResult<T>` or `HttpResult`; use `if (!result.Success) { Console.WriteLine(result.Error); return; }` |
+| Socket subscription success check | Socket subscriptions return `WebSocketResult<UpdateSubscription>`; use `if (!sub.Success) { Console.WriteLine(sub.Error); return; }` |
+| Read result data | Read `result.Data` or `sub.Data` only after `.Success` |
 | Order accepted check | Check `order.Data.Success` after `order.Success` |
 | Cancellation | Pass `ct: cancellationToken` |
 | Retry decision | Retry only when `result.Error?.IsTransient == true` |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -24,8 +24,8 @@ Primary documentation:
 - Do not generate raw `HttpClient` calls to Polymarket endpoints.
 - Do not manually sign CLOB requests; use `PolymarketCredentials`.
 - Always check `.Success` before reading `.Data`.
-- REST methods return `WebCallResult<T>` or `WebCallResult`.
-- WebSocket subscriptions return `CallResult<UpdateSubscription>`.
+- REST methods return `HttpResult<T>` or `HttpResult`.
+- WebSocket subscriptions return `WebSocketResult<UpdateSubscription>`.
 - Reuse clients. Do not instantiate clients per request in production code.
 - Prefer dependency injection for long-running applications.
 - Store WebSocket subscriptions and unsubscribe during shutdown.
@@ -307,9 +307,9 @@ Console.WriteLine(order.Data.OrderId);
 Retry only transient failures:
 
 ```csharp
-async Task<WebCallResult<T>> WithRetry<T>(Func<Task<WebCallResult<T>>> call, int maxAttempts = 3)
+async Task<HttpResult<T>> WithRetry<T>(Func<Task<HttpResult<T>>> call, int maxAttempts = 3)
 {
-    WebCallResult<T> last = default!;
+    HttpResult<T> last = default!;
 
     for (var attempt = 1; attempt <= maxAttempts; attempt++)
     {
@@ -535,7 +535,7 @@ Examples/ai-friendly/04-di-and-orderbook.cs
   AddPolymarket DI setup, injected clients, local order book factory, user client provider.
 
 Examples/ai-friendly/05-error-handling.cs
-  WebCallResult pattern, transient retry, order result acceptance checks, Polymarket-specific mistakes.
+  HttpResult pattern, transient retry, order result acceptance checks, Polymarket-specific mistakes.
 ```
 
 These files are intended to be copied into a console `Program.cs` after `dotnet add package Polymarket.Net`.
@@ -554,7 +554,7 @@ Before finalizing generated code:
 - Does authenticated trading configure or derive L2 credentials?
 - Does it avoid `.Result` and `.Wait()`?
 - Are WebSocket subscriptions unsubscribed on shutdown?
-- For order placement, does it check both `WebCallResult.Success` and `PolymarketOrderResult.Success`?
+- For order placement, does it check both `HttpResult.Success` and `PolymarketOrderResult.Success`?
 - If using local order books, does it prefer `PolymarketClobSymbolOrderBook` or `IPolymarketOrderBookFactory`?
 
 ## Source Of Truth For Method Names

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -25,7 +25,7 @@ Primary documentation:
 - Do not manually sign CLOB requests; use `PolymarketCredentials`.
 - Always check `.Success` before reading `.Data`.
 - REST methods return `HttpResult<T>` or `HttpResult`.
-- WebSocket subscriptions return `WebSocketResult<UpdateSubscription>`.
+- WebSocket subscription methods return `WebSocketResult<UpdateSubscription>`.
 - Reuse clients. Do not instantiate clients per request in production code.
 - Prefer dependency injection for long-running applications.
 - Store WebSocket subscriptions and unsubscribe during shutdown.
@@ -327,6 +327,8 @@ async Task<HttpResult<T>> WithRetry<T>(Func<Task<HttpResult<T>>> call, int maxAt
 }
 ```
 
+Socket subscription methods use the same `.Success` and `.Error` pattern and return `WebSocketResult<UpdateSubscription>`.
+
 ## Intent To Method Map
 
 For a broader table-style reference, see `docs/ai-api-map.md`.
@@ -529,13 +531,13 @@ Examples/ai-friendly/02-authentication-and-trading.cs
   L1/L2 credentials, deriving L2 credentials, allowance checks, limit order, open order lookup, cancellation.
 
 Examples/ai-friendly/03-websocket.cs
-  Token, platform, sports, and user WebSocket subscriptions, success checks, teardown.
+  Token, platform, sports, and user WebSocket subscriptions, WebSocketResult checks, teardown.
 
 Examples/ai-friendly/04-di-and-orderbook.cs
   AddPolymarket DI setup, injected clients, local order book factory, user client provider.
 
 Examples/ai-friendly/05-error-handling.cs
-  HttpResult pattern, transient retry, order result acceptance checks, Polymarket-specific mistakes.
+  HttpResult and WebSocketResult patterns, transient retry, order result acceptance checks, Polymarket-specific mistakes.
 ```
 
 These files are intended to be copied into a console `Program.cs` after `dotnet add package Polymarket.Net`.

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 > Strongly typed .NET client library for the Polymarket REST and WebSocket APIs. Supports CLOB market data, Gamma events/markets/tags/search, Data API positions, CLOB trading/account endpoints, local order books, user client management, L1/L2 authentication, and WebSocket streams. Part of the CryptoExchange.Net ecosystem.
 
-Polymarket.Net provides typed C# access to Polymarket prediction market APIs with `HttpResult<T>` / `WebSocketResult<T>` error handling, client-side rate limiting, automatic WebSocket reconnection, native AOT support, and dependency injection. Current repository package version: 3.4.0. Targets netstandard2.0, netstandard2.1, net8.0, net9.0, net10.0.
+Polymarket.Net provides typed C# access to Polymarket prediction market APIs with `HttpResult<T>` / `HttpResult` REST handling and `WebSocketResult<UpdateSubscription>` subscription handling, client-side rate limiting, automatic WebSocket reconnection, native AOT support, and dependency injection. Current repository package version: 3.4.0. Targets netstandard2.0, netstandard2.1, net8.0, net9.0, net10.0.
 
 ## Documentation
 
@@ -31,6 +31,7 @@ Polymarket.Net provides typed C# access to Polymarket prediction market APIs wit
 - Public data can be requested without credentials.
 - L1 credentials use `PolymarketCredentials.WithL1(...)` / `PolymarketL1Credential`; L2 credentials use `.WithL2(...)` / `HMACPassCredential`.
 - Create or derive L2 credentials with `GetOrCreateApiCredentialsAsync()` before private trading when only L1 credentials are configured.
+- REST calls return `HttpResult<T>` or `HttpResult`; socket subscriptions return `WebSocketResult<UpdateSubscription>`.
 
 ## Reference
 

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 > Strongly typed .NET client library for the Polymarket REST and WebSocket APIs. Supports CLOB market data, Gamma events/markets/tags/search, Data API positions, CLOB trading/account endpoints, local order books, user client management, L1/L2 authentication, and WebSocket streams. Part of the CryptoExchange.Net ecosystem.
 
-Polymarket.Net provides typed C# access to Polymarket prediction market APIs with `WebCallResult<T>` / `CallResult<T>` error handling, client-side rate limiting, automatic WebSocket reconnection, native AOT support, and dependency injection. Current repository package version: 3.4.0. Targets netstandard2.0, netstandard2.1, net8.0, net9.0, net10.0.
+Polymarket.Net provides typed C# access to Polymarket prediction market APIs with `HttpResult<T>` / `WebSocketResult<T>` error handling, client-side rate limiting, automatic WebSocket reconnection, native AOT support, and dependency injection. Current repository package version: 3.4.0. Targets netstandard2.0, netstandard2.1, net8.0, net9.0, net10.0.
 
 ## Documentation
 
@@ -19,7 +19,7 @@ Polymarket.Net provides typed C# access to Polymarket prediction market APIs wit
 - [Authentication And Trading](https://github.com/JKorf/Polymarket.Net/blob/main/Examples/ai-friendly/02-authentication-and-trading.cs): L1/L2 credentials, deriving L2 credentials, allowance check, limit order, open orders, cancellation
 - [WebSocket Streams](https://github.com/JKorf/Polymarket.Net/blob/main/Examples/ai-friendly/03-websocket.cs): Token, platform, sports, and authenticated user subscriptions with teardown
 - [Dependency Injection And Order Book](https://github.com/JKorf/Polymarket.Net/blob/main/Examples/ai-friendly/04-di-and-orderbook.cs): `AddPolymarket`, client injection, local order book factory, per-user client provider
-- [Error Handling](https://github.com/JKorf/Polymarket.Net/blob/main/Examples/ai-friendly/05-error-handling.cs): `WebCallResult` pattern, retry helper, order result checks, common Polymarket mistakes
+- [Error Handling](https://github.com/JKorf/Polymarket.Net/blob/main/Examples/ai-friendly/05-error-handling.cs): `HttpResult` pattern, retry helper, order result checks, common Polymarket mistakes
 - [Full Examples Repository](https://github.com/JKorf/Polymarket.Net/tree/main/Examples): Console, API, tracker, and local order book examples
 
 ## Critical Rules


### PR DESCRIPTION
* Result types:
  * (Web)CallResult types are replaced by HttpResult and WebSocketResult with the same logic
  * WebSocketResult now return additional info for websocket operations
  * Updated result types to record type
  * Removed implicit result type conversion to bool, `if (result)` no longer works, instead use `if (result.Success)`
  * Fixed result object nullability hinting, for example Data might be null if Success isn't checked for true

* Clients:
  * Added ToString overrides on base API types
  * Added Exchange property on BaseApiClient
  * Added ApiCredentials property on Api clients
  * Updated ILogger source from client name to topic specific client name
  * Removed logging from client creation
  * Fixed issue in SocketApiClient.GetSocketConnection causing requests to always wait the full max 10 seconds when there was a reconnecting socket

* Added bypass of order book request for place order if possible
* Added SupportedEnvironments property to PlatformInfo
* Added setter to PolymarketPlatform.RateLimiter to allow custom rate limit settings
* Various small performance improvements
* Fixed websocket connection attempts counting towards rate limit even when server could not be reached
